### PR TITLE
ci: run the smoke test on stable and nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        neovim: [stable, nightly]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: ${{ matrix.neovim }}
+
+      # Loads every depth through nvim_set_hl, which throws on a missing palette
+      # key, then asserts the published contrast ratios and the role map.
+      - name: Smoke test
+        run: nvim --headless --noplugin -u NONE -c "set rtp+=." -c "luafile test/smoke.lua"


### PR DESCRIPTION
Runs the assertions from the previous pull request on every push to main and on every pull request.

Two Neovim versions, stable and nightly, with `fail-fast` off so a break on nightly shows up while stable is still green rather than after it is not.

The workflow only runs what exists today. The help tags step and the extras drift check arrive in the pull requests that add the help file and the generated surfaces, so each check lands with the thing it checks.