### PR TITLE
feat(lualine): a theme that follows the active depth

### DIFF
--- a/lua/lualine/themes/cendre.lua
+++ b/lua/lualine/themes/cendre.lua
@@ -1,0 +1,40 @@
+local ok, cendre = pcall(require, "cendre")
+local c = require("cendre.palette").get(ok and cendre.config.background or "hard")
+
+-- Mode colour tracks the semantic family, not the syntax pigments: the mode
+-- block should never look like a token.
+local cendre = {}
+
+cendre.normal = {
+  a = { fg = c.bg0, bg = c.ember, gui = "bold" },
+  b = { fg = c.fg, bg = c.bg2 },
+  c = { fg = c.fg_dim, bg = c.bg1 },
+}
+
+cendre.insert = {
+  a = { fg = c.bg0, bg = c.ok, gui = "bold" },
+}
+
+cendre.visual = {
+  a = { fg = c.bg0, bg = c.info, gui = "bold" },
+}
+
+cendre.replace = {
+  a = { fg = c.bg0, bg = c.error, gui = "bold" },
+}
+
+cendre.command = {
+  a = { fg = c.bg0, bg = c.brass, gui = "bold" },
+}
+
+cendre.terminal = {
+  a = { fg = c.bg0, bg = c.hint, gui = "bold" },
+}
+
+cendre.inactive = {
+  a = { fg = c.gutter, bg = c.bg1 },
+  b = { fg = c.gutter, bg = c.bg1 },
+  c = { fg = c.gutter, bg = c.bg1 },
+}
+
+return cendre

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -329,6 +329,15 @@ check("nothing readable depends on bold or italic", function()
   end
 end)
 
+check("lualine theme follows the active background", function()
+  reload()
+  require("cendre").setup({ background = "soft" })
+  require("cendre").load()
+  package.loaded["lualine.themes.cendre"] = nil
+  local theme = require("lualine.themes.cendre")
+  assert(theme.normal.c.bg == require("cendre.palette").grounds.soft.bg1,
+    "lualine still on the wrong ground")
+end)
 
 print(("-"):rep(52))
 if #failures > 0 then


### PR DESCRIPTION
A lualine theme that reads the palette at the depth currently loaded, so switching with `:CendreBackground` moves the statusline with the buffer.

The mode colour comes from the semantic family rather than from the syntax pigments. A mode block wearing the same red as a keyword reads as a token, which is not what it is.

`theme = "auto"` finds it, so most people need no configuration.

The assertion switches to `soft` and reads the theme back, rather than trusting that it was built from the same table.