### PR TITLE
docs: the readme and the vimdoc help file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,7 @@ jobs:
       # key, then asserts the published contrast ratios and the role map.
       - name: Smoke test
         run: nvim --headless --noplugin -u NONE -c "set rtp+=." -c "luafile test/smoke.lua"
+
+      # Now that doc/cendre.txt exists, the tags it advertises have to build.
+      - name: Help tags build
+        run: nvim --headless --noplugin -u NONE -c "set rtp+=." -c "helptags doc" -c q

--- a/README.md
+++ b/README.md
@@ -1,0 +1,214 @@
+<p align="center">
+  <img src="assets/banner.svg" alt="cendre" width="880">
+</p>
+
+Dark colorscheme for Neovim. One wood fire, taken apart.
+
+Every pigment hue was computed from something measurable in a burning log:
+Planck's law for the coals, published emission wavelengths for everything else,
+pushed through the CIE 1931 colour matching functions into OKLCH. Lightness and
+chroma are chosen, because a spectral line sits far outside sRGB and has to be
+brought into gamut anyway. Nothing was nudged toward a nicer number.
+
+Dark only, on purpose. Every hue, ratio and surface is laid out at
+**[cendretheme.com](https://cendretheme.com/)**.
+
+```lua
+{ "Aejkatappaja/cendre" }
+```
+
+Neovim 0.9 or newer, with `termguicolors`.
+
+<img src="assets/editor.svg" alt="Go code in cendre, with git signs, diagnostics and a statusline" width="880">
+
+Diagnostics, git signs, diff and statusline draw from the semantic family. An
+error never wears the same red as a keyword.
+
+## Three depths, one palette
+
+The pigments are the identity, so they never move. Only the ground under them
+does, at three depths. A screenshot at one depth is recognisably the same theme
+as a screenshot at another, which is the whole point.
+
+| depth    | bg0       | L     | text     | comment | dimmest pigment |
+| -------- | --------- | ----- | -------- | ------- | --------------- |
+| `hard`   | `#171311` | 0.191 | 12.89:1  | 3.32:1  | 4.77:1          |
+| `medium` | `#1d1917` | 0.217 | 12.18:1  | 3.14:1  | 4.51:1          |
+| `soft`   | `#231f1d` | 0.243 | 11.41:1  | 2.94:1  | 4.22:1          |
+
+`hard` is the default. It is deeper than any theme this was measured against, and
+is the reason the ramp above it has to be finely stepped. `soft` is lifted to
+where the dark themes people keep for years actually sit.
+
+Switch at runtime, no restart:
+
+```
+:CendreBackground soft
+:CendreBackground hard
+```
+
+## Install
+
+lazy.nvim:
+
+```lua
+{
+  "Aejkatappaja/cendre",
+  lazy = false,
+  priority = 1000,
+  config = function()
+    require("cendre").setup({
+      background = "hard", -- "hard" | "medium" | "soft"
+      italic = false,
+    })
+  end,
+},
+{
+  "LazyVim/LazyVim",
+  opts = { colorscheme = "cendre" },
+}
+```
+
+Without LazyVim, just `vim.cmd.colorscheme("cendre")` after setup.
+
+lualine picks it up with `options.theme = "cendre"`, or leave `"auto"`.
+
+`:help cendre` covers the options, the commands and the role map in full.
+
+## Options
+
+| option            | default    | effect                                                   |
+| ----------------- | ---------- | -------------------------------------------------------- |
+| `background`      | `"hard"`   | ground depth: `hard`, `medium` or `soft`                  |
+| `transparent`     | `false`    | strips the background off Normal, floats, statusline      |
+| `italic`          | `false`    | italics across the theme                                  |
+| `italic_comments` | `true`     | keeps comments italic even when `italic = false`           |
+| `on_colors`       | noop       | `function(colors)` mutates the palette before highlights  |
+| `on_highlights`   | noop       | `function(highlights, colors)` gets the last word         |
+
+The background is painted by default. The ash bed is a colour the theme derived,
+so it may as well be on screen.
+
+```lua
+require("cendre").setup({
+  on_highlights = function(hl, c)
+    hl.Comment = { fg = c.bg5 }
+  end,
+})
+```
+
+## Palette
+
+Ground, hue 43°, which is wood ash under a 1300 K flame. Ash is spectrally flat,
+so it lands within a degree of the bare flame itself. Shown at `hard`, the default:
+
+| token     | hex       | L     | use                |
+| --------- | --------- | ----- | ------------------ |
+| `bg_deep` | `#0f0c0a` | 0.156 | floats, sidebars   |
+| `bg0`     | `#171311` | 0.191 | editor             |
+| `bg1`     | `#201b19` | 0.227 | cursorline         |
+| `bg2`     | `#2a2422` | 0.266 | statusline         |
+| `bg3`     | `#362f2c` | 0.312 | borders, splits    |
+| `bg4`     | `#463e3a` | 0.371 | hover              |
+| `bg5`     | `#5a504c` | 0.440 | highest layer      |
+
+Ink, shared by every depth. Ratios against `bg0` at `hard`:
+
+| token     | hex       | ratio   | use                   |
+| --------- | --------- | ------- | --------------------- |
+| `fg`      | `#e6d5c2` | 12.89:1 | body text             |
+| `fg_dim`  | `#a09384` |  6.15:1 | operators, delimiters |
+| `comment` | `#73665b` |  3.32:1 | comments              |
+| `gutter`  | `#4e4641` |  2.00:1 | line numbers, inlay   |
+
+`comment` is deliberately under AA. Every dark theme people keep for years puts
+comments below that line, most around 3.3:1, and a comment as loud as the code
+it explains is noise.
+
+The five pigments, in order of lightness, which is also order of distance from
+the fire:
+
+| name     | hue    | L     | source              | role                            |
+| -------- | ------ | ----- | ------------------- | ------------------------------- |
+| `brass`  |  61.4° | 0.838 | sodium D 589 nm     | functions, methods, calls       |
+| `ember`  |  43.8° | 0.754 | blackbody 1300 K    | properties, fields, params, UI  |
+| `sap`    | 123.4° | 0.721 | C₂ Swan 563 nm      | every literal value             |
+| `cinder` |  25.9° | 0.665 | CaOH band 622 nm    | keywords, control flow, storage |
+| `frost`  | 227.4° | 0.600 | C₂ Swan 474 nm      | types, classes, constructors    |
+
+Arc 202°, smallest gap 17.6°, chroma 0.072 to 0.115. A fire does not offer
+well-spaced warm hues: cinder, ember and brass sit within 36° of each other
+because that is where calcium, soot and sodium actually are. They stay legible
+on lightness instead, which is also why `brass` is the brightest thing on screen
+and `frost` the dimmest.
+
+Semantic colours (`error` `warn` `ok` `hint` `info`) are a separate family, all
+carrying more chroma than any pigment, so a diagnostic never wears the same red
+as a keyword. Chroma is held inside 0.125 to 0.160: unbounded, the optimiser
+that placed them produced neon.
+
+Each hue traced from its spectrum to its hex:
+[cendretheme.com/#derivation](https://cendretheme.com/#derivation).
+
+## Rules it obeys
+
+1. Hue comes from the source, separation is bought with lightness.
+2. One role, one pigment. No token depends on bold or italic.
+3. A declared name is not a role. Variables and constant names stay in `fg`, and
+   only the value a constant holds takes a pigment.
+4. Punctuation is not a token. Operators, commas and brackets take `fg_dim`.
+5. Diagnostics are their own family, separate from the pigments.
+6. Nothing readable under 4.5:1, with three exceptions that are stated rather
+   than hidden: `comment` everywhere, and `frost` and `error` on `soft`.
+
+## Everywhere else
+
+Nothing under `extras/` or `assets/` is written by hand, nor the favicon and share
+card under `docs/`. All of it is rendered from `lua/cendre/palette.lua`, so a
+colour cannot be right in the editor and stale in a terminal, in this README, or
+on the site:
+
+```sh
+nvim --headless --noplugin -u NONE -c "set rtp+=." -c "luafile scripts/extras.lua" -c q
+```
+
+**Every surface ships at all three depths.** A reader on `soft` wants `soft` in
+their terminal too, so each directory holds `cendre`, `cendre-medium` and
+`cendre-soft`. The unsuffixed name is the depth the plugin defaults to, so the
+editor and everything around it match with no second decision.
+
+Anything that stores a theme name rather than taking it from its filename gets
+that name qualified per depth, or installing two of them collides on one entry in
+Zed, bat, Obsidian and the rest. The test asserts that.
+
+The full list, with the path each one installs to:
+[cendretheme.com/#surfaces](https://cendretheme.com/#surfaces).
+
+Ghostty, for example:
+
+```
+theme = cendre
+```
+
+The 16 ANSI slots are also exported as `vim.g.terminal_color_*`, so `:terminal`
+matches. Slot 5 is potassium's 404 nm line, derived the same way as the pigments,
+and it exists because ANSI wants six hues while the editor needs five.
+
+## Test
+
+```sh
+nvim --headless --noplugin -u NONE -c "set rtp+=." -c "luafile test/smoke.lua"
+```
+
+Loads every depth through `nvim_set_hl`, which throws on a missing palette key,
+then asserts that the switches behave, that `:CendreBackground` swaps the live
+ground and rejects junk, that the pigments never drift between depths, that no
+pigment collides with a diagnostic, that every published contrast ratio is what
+the code actually measures, that the role map lands where this README says, that
+no readable token leans on bold or italic, and that every committed file under
+`extras/`, `assets/` and `docs/` matches a fresh render of the palette. Exits
+non-zero on failure.
+
+## Licence
+
+MIT.

--- a/doc/cendre.txt
+++ b/doc/cendre.txt
@@ -1,0 +1,303 @@
+*cendre.txt*                        A dark colorscheme derived from a wood fire
+
+                       one wood fire, taken apart
+                    five pigments, none of them chosen
+
+==============================================================================
+CONTENTS                                                     *cendre-contents*
+
+  1. Introduction ............................. |cendre-introduction|
+  2. Requirements ............................. |cendre-requirements|
+  3. Installation ............................. |cendre-installation|
+  4. Configuration ............................ |cendre-configuration|
+  5. Commands ................................. |cendre-commands|
+  6. Depths ................................... |cendre-depths|
+  7. Palette .................................. |cendre-palette|
+  8. Roles .................................... |cendre-roles|
+  9. Extras ................................... |cendre-extras|
+ 10. Lualine .................................. |cendre-lualine|
+ 11. Extending ................................ |cendre-extending|
+ 12. Tests .................................... |cendre-tests|
+
+==============================================================================
+1. INTRODUCTION                                          *cendre-introduction*
+
+Cendre is a dark colorscheme for Neovim. Dark only, on purpose.
+
+No hue in it was chosen. Every one was computed from something measurable in a
+burning log: Planck's law at 1300 K for the coals, published emission
+wavelengths for the rest, pushed through the CIE 1931 colour matching
+functions into OKLCH.
+
+Lightness and chroma are choices, because a spectral line sits far outside
+sRGB and has to be brought into gamut anyway. Nothing was nudged toward a
+nicer number.
+
+The derivation is shown step by step, and every surface listed, at
+https://cendretheme.com/
+
+==============================================================================
+2. REQUIREMENTS                                          *cendre-requirements*
+
+  - Neovim 0.9 or newer
+  - 'termguicolors' (cendre sets it on load)
+
+A terminal with true colour support. Without it the ANSI slots apply but the
+pigments do not, and the theme is not worth running.
+
+==============================================================================
+3. INSTALLATION                                          *cendre-installation*
+
+With lazy.nvim: >lua
+
+    {
+      "Aejkatappaja/cendre",
+      lazy = false,
+      priority = 1000,
+      config = function()
+        require("cendre").setup({
+          background = "hard",
+          italic = false,
+        })
+      end,
+    }
+<
+Then either let LazyVim pick it up: >lua
+
+    { "LazyVim/LazyVim", opts = { colorscheme = "cendre" } }
+<
+or set it yourself: >lua
+
+    vim.cmd.colorscheme("cendre")
+<
+|cendre.setup()| is optional. Loading the colorscheme without it applies every
+default below.
+
+==============================================================================
+4. CONFIGURATION                                        *cendre-configuration*
+
+                                                            *cendre.setup()*
+require("cendre").setup({opts})
+
+Accepts a table. Every key is optional; pass only what you want to change.
+
+    background          string      default "hard"
+
+        Ground depth: "hard", "medium" or "soft". The pigments never move, so
+        this changes only what sits under them. See |cendre-depths|.
+        An unknown value falls back to "hard" rather than erroring.
+
+    transparent         boolean     default false
+
+        Strips the background from Normal, floats, statusline and tabline, so
+        the terminal shows through. Off by default: the ash bed is a colour
+        the theme derived, so it may as well be on screen.
+
+        The float border keeps its stroke when this is on, because a
+        transparent float with no border has no edge.
+
+    italic              boolean     default false
+
+        Italics across the theme. Every role keeps a real gap from the
+        others, so italics carry no information here.
+
+    italic_comments     boolean     default true
+
+        Keeps comments italic even when `italic` is false. Set both to false
+        for no italics anywhere.
+
+    on_colors           function    default noop
+
+        `function(colors)`. Runs after the palette resolves and before any
+        highlight is built, so mutating a key here changes every group that
+        uses it. >lua
+
+            require("cendre").setup({
+              on_colors = function(c)
+                c.bg0 = "#000000"
+              end,
+            })
+<
+    on_highlights       function    default noop
+
+        `function(highlights, colors)`. Runs last and wins over everything,
+        including `transparent` and the italic switches. >lua
+
+            require("cendre").setup({
+              on_highlights = function(hl, c)
+                hl.Comment = { fg = c.bg5 }
+                hl["@keyword"] = { fg = c.brass, bold = true }
+              end,
+            })
+<
+==============================================================================
+5. COMMANDS                                                  *cendre-commands*
+
+                                                        *:CendreBackground*
+:CendreBackground [{depth}]
+
+    Switch the ground depth at runtime, no restart. {depth} is "hard",
+    "medium" or "soft"; with no argument it goes back to "hard". Tab
+    completion offers the three.
+
+    An unknown name is rejected with a message and leaves the current depth
+    alone. >
+
+        :CendreBackground soft
+        :CendreBackground
+<
+    The command is registered when the colorscheme loads, not only by
+    |cendre.setup()|, because a bare `colorscheme cendre` with no configuration
+    is a supported way to install this and should not be the way that silently
+    loses the command.
+
+==============================================================================
+6. DEPTHS                                                      *cendre-depths*
+
+Three depths, one palette. The pigments are the identity, so they never move:
+only the seven-step ground under them does. A screenshot at one depth is
+recognisably the same theme as a screenshot at another, which is the point.
+
+    depth     bg0        L       text      comment   dimmest pigment ~
+    hard      #171311    0.191   12.89:1   3.32:1    4.77:1
+    medium    #1d1917    0.217   12.18:1   3.14:1    4.51:1
+    soft      #231f1d    0.243   11.41:1   2.94:1    4.22:1
+
+`hard` is the default. It is deeper than any theme cendre was measured
+against, which is why the ramp above it is finely stepped. `soft` is lifted to
+where the dark themes people keep for years actually sit.
+
+Comments sit under the accessibility floor on purpose. Every dark theme people
+keep for years puts them there, most around 3.3:1, and a comment as loud as
+the code it explains is noise.
+
+==============================================================================
+7. PALETTE                                                    *cendre-palette*
+
+The ground is hue 43°, which is wood ash under a 1300 K flame. Ash is
+spectrally flat, so it lands within a degree of the bare flame.
+
+Ink, shared by every depth:
+
+    fg        #e6d5c2    body text ~
+    fg_dim    #a09384    operators, delimiters
+    comment   #73665b    comments
+    gutter    #4e4641    line numbers, inlay hints
+
+The five pigments, in order of lightness, which is also order of distance
+from the fire:
+
+    name      hue       L       source              ~
+    brass     61.4°     0.838   sodium D 589 nm
+    ember     43.8°     0.754   blackbody 1300 K
+    sap       123.4°    0.721   C2 Swan 563 nm
+    cinder    25.9°     0.665   CaOH band 622 nm
+    frost     227.4°    0.600   C2 Swan 474 nm
+
+Arc 202°, smallest gap 17.6°, chroma 0.072 to 0.115. A fire does not offer
+well-spaced warm hues: cinder, ember and brass sit within 36° of each other
+because that is where calcium, soot and sodium are. They stay legible on
+lightness instead of hue distance.
+
+Diagnostics are a separate family (`error` `warn` `ok` `hint` `info`), all
+carrying more chroma than any pigment, so an error never wears the same red as
+a keyword.
+
+The whole table is available at runtime: >lua
+
+    local colors = require("cendre.palette").get("hard")
+    local name = require("cendre.palette").name("soft")   -- "cendre-soft"
+<
+==============================================================================
+8. ROLES                                                        *cendre-roles*
+
+One role, one pigment. No token depends on bold or italic.
+
+    cinder    keywords, control flow, storage ~
+    ember     properties, fields, parameters, and the UI accent
+    brass     functions, methods, calls
+    sap       every literal value: strings, numbers, booleans, nil
+    frost     types, classes, constructors, modules
+
+Two rules that follow from that:
+
+    - A declared name is not a role. Variables and constant names stay in
+      `fg`; only the value a constant holds takes a pigment.
+    - Punctuation is not a token. Operators, commas and brackets take
+      `fg_dim`.
+
+Orange does syntax work here. Properties, fields and parameters are among the
+most frequent tokens in a real file, so that is where the warmth goes.
+
+==============================================================================
+9. EXTRAS                                                      *cendre-extras*
+
+Twenty-four surfaces beyond the editor ship under `extras/`: terminals,
+prompts, pagers, TUIs, Vim, Helix, Zed, Obsidian and more.
+
+Every one of them is rendered from `lua/cendre/palette.lua` and nothing else,
+so a colour cannot be right in Neovim and stale in a terminal. Hand-editing a
+generated file is a test failure, not a silent divergence. Regenerate with: >
+
+    nvim --headless --noplugin -u NONE -c "set rtp+=." \
+      -c "luafile scripts/extras.lua" -c q
+<
+Each surface ships at all three depths. The unsuffixed file is the depth the
+plugin defaults to, and `-medium` and `-soft` sit beside it. Anything that
+stores a theme name rather than taking it from its filename carries that name
+qualified per depth, or installing two of them collides on one entry.
+
+The 16 ANSI slots are exported as `vim.g.terminal_color_0` through
+`vim.g.terminal_color_15`, so |:terminal| matches. Slot 5 is potassium's
+404 nm line, derived the same way as the pigments; it exists because ANSI
+wants six hues where the editor needs five, and it never touches a token.
+
+==============================================================================
+10. LUALINE                                                   *cendre-lualine*
+
+A lualine theme ships with the plugin and follows the active depth: >lua
+
+    require("lualine").setup({ options = { theme = "cendre" } })
+<
+`theme = "auto"` also finds it. The mode colour comes from the semantic
+family, not from the syntax pigments, so the mode block never looks like a
+token.
+
+==============================================================================
+11. EXTENDING                                              *cendre-extending*
+
+|cendre.setup()| exposes two hooks, and the order they run in is what makes
+them useful:
+
+    1. the palette resolves for the chosen depth
+    2. `on_colors` mutates it
+    3. every highlight group is built from the result
+    4. `transparent` strips backgrounds, the italic switches apply
+    5. `on_highlights` runs, and wins
+
+So `on_colors` is for changing a colour everywhere at once, and
+`on_highlights` is for overriding one group regardless of anything else.
+
+The resolved table is also on the module after a load: >lua
+
+    require("cendre").colors.ember
+<
+==============================================================================
+12. TESTS                                                      *cendre-tests*
+
+The claims in this file are asserted rather than documented: >
+
+    nvim --headless --noplugin -u NONE -c "set rtp+=." \
+      -c "luafile test/smoke.lua"
+<
+It loads every depth through |nvim_set_hl()|, which throws on a missing
+palette key, then checks that the switches behave, that |:CendreBackground|
+swaps the live ground and rejects junk, that the pigments never drift between
+depths, that no pigment collides with a diagnostic, that every contrast ratio
+printed above is what the code actually measures, that the role map lands
+where section 8 says, that no readable token leans on bold or italic, and that
+every committed file under `extras/`, `assets/` and `docs/` matches a fresh
+render of the palette. It exits non-zero on failure.
+
+==============================================================================
+vim:tw=78:ts=8:sw=8:noet:ft=help:norl:

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -396,6 +396,33 @@ check("the committed extras match a fresh render of the palette", function()
   assert(n > 0, "no extras were rendered at all")
 end)
 
+check("the help file exists and defines a tag per section", function()
+  local doc = io.open("doc/cendre.txt", "r")
+  assert(doc, "doc/cendre.txt is missing, so :help cendre fails")
+  local body = doc:read("*a")
+  doc:close()
+
+  local seen = {}
+  for tag in body:gmatch("%*([%w%.%-_():]+)%*") do
+    assert(not seen[tag], "duplicate help tag " .. tag)
+    seen[tag] = true
+  end
+
+  -- every documented option and command has to be reachable by :help
+  for _, tag in ipairs({
+    "cendre-contents", "cendre-installation", "cendre-configuration",
+    "cendre-commands", "cendre-depths", "cendre-palette", "cendre-roles",
+    "cendre-extras", "cendre.setup()", ":CendreBackground",
+  }) do
+    assert(seen[tag], "no help tag for " .. tag)
+  end
+
+  -- and every cross-reference inside the file has to land on one of them
+  for ref in body:gmatch("|(cendre[%w%.%-_():]*)|") do
+    assert(seen[ref], "help references |" .. ref .. "| but nothing defines it")
+  end
+end)
+
 check("lualine theme follows the active background", function()
   reload()
   require("cendre").setup({ background = "soft" })


### PR DESCRIPTION
The two places somebody reads about cendre before installing it.

## README

Leads with what makes the theme worth a look: no hue in it was chosen. Then the depth table, the full palette with its measured ratios, the role map, and the rules the theme obeys.

Every number in it is asserted rather than typed once and left to rot. The depth table, the four ink ratios and the role map all come back from the palette on each test run, so changing a hex fails the build until the tables agree.

## Help file

Twelve sections behind `:help cendre`: requirements, installation, the options with their defaults, `:CendreBackground`, the depths, the palette, the role map, the extras, lualine, and the order the two hooks run in.

`doc/tags` stays ignored, since `:helptags` and every plugin manager write it on install.

## Two checks, not one

The test collects every tag the file defines and verifies that each `|reference|` inside it resolves, because a cross-reference landing nowhere is a dead end for anybody reading in Neovim.

The workflow gains a `helptags` step, which is a different failure: the file can define its tags correctly and still not index.