### PR TITLE
feat(site): serve the page from cendretheme.com

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+cendretheme.com


### PR DESCRIPTION
The domain is registered and its DNS resolves, so `docs/CNAME` can finally land.

```
A     @     185.199.108.153
A     @     185.199.109.153
A     @     185.199.110.153
A     @     185.199.111.153
CNAME www   aejkatappaja.github.io.
```

It was held back on purpose. A CNAME file makes Pages redirect its own address to the custom domain, so committing it before the domain resolved would have taken the site down at `aejkatappaja.com/cendre` as well, and you could not have checked your own deploy.

Landing it also repairs the head of the page without touching it. The canonical link, `og:url`, `og:image` and `twitter:image` have named `cendretheme.com` since the page was written, which meant share previews had no image and search engines were told the real address was a domain that did not exist. They become correct the moment this merges.