### PR TITLE
fix(transparent): let plugin windows inherit the float surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ lualine picks it up with `options.theme = "cendre"`, or leave `"auto"`.
 | option            | default    | effect                                                   |
 | ----------------- | ---------- | -------------------------------------------------------- |
 | `background`      | `"hard"`   | ground depth: `hard`, `medium` or `soft`                  |
-| `transparent`     | `false`    | strips the background off Normal, floats, statusline      |
+| `transparent`     | `false`    | strips Normal, floats and the statusline; plugin windows follow |
 | `italic`          | `false`    | italics across the theme                                  |
 | `italic_comments` | `true`     | keeps comments italic even when `italic = false`           |
 | `on_colors`       | noop       | `function(colors)` mutates the palette before highlights  |
@@ -88,6 +88,12 @@ lualine picks it up with `options.theme = "cendre"`, or leave `"auto"`.
 
 The background is painted by default. The ash bed is a colour the theme derived,
 so it may as well be on screen.
+
+With `transparent = true`, plugin windows go through too, without being listed one
+by one: which-key, the Snacks picker, Noice and fzf-lua link their windows to
+`NormalFloat`, so stripping that strips all of them, including plugins released
+after this README. The completion menu is the exception and stays painted, since a
+transparent popup over code is not readable.
 
 ```lua
 require("cendre").setup({

--- a/doc/cendre.txt
+++ b/doc/cendre.txt
@@ -96,6 +96,13 @@ Accepts a table. Every key is optional; pass only what you want to change.
         The float border keeps its stroke when this is on, because a
         transparent float with no border has no edge.
 
+        Plugin windows follow, without being named one by one. which-key, the
+        Snacks picker, Noice, fzf-lua and the rest link their windows to
+        `NormalFloat` and their edges to `FloatBorder`, so stripping those two
+        strips every one of them, including plugins released after this file.
+        The completion menu is the exception and stays painted: a transparent
+        popup over code is not readable.
+
     italic              boolean     default false
 
         Italics across the theme. Every role keeps a real gap from the

--- a/lua/cendre/groups/integrations.lua
+++ b/lua/cendre/groups/integrations.lua
@@ -1,6 +1,14 @@
 local M = {}
 
 -- Plugins you actually run, per lazyvim.json + your colorscheme.lua.
+--
+-- Only what a plugin colours differently from a plain float belongs here. The
+-- window surfaces themselves are deliberately absent: every one of these plugins
+-- already links its window to NormalFloat and its edge to FloatBorder, so naming
+-- them again would render identically while pinning the colour, and a pinned
+-- colour is one `transparent = true` cannot strip. That is what used to leave
+-- which-key, the Snacks picker, Noice and fzf-lua opaque over the terminal.
+-- Colour NormalFloat and FloatBorder, and the windows follow.
 function M.get(c)
   return {
     -- gitsigns
@@ -21,17 +29,9 @@ function M.get(c)
     SnacksNormalNC          = { fg = c.fg, bg = c.bg_deep },
     SnacksWinBar            = { fg = c.ember, bold = true },
     SnacksBackdrop          = { bg = c.bg_deep },
-    SnacksPicker            = { fg = c.fg, bg = c.bg_deep },
-    SnacksPickerBorder      = { fg = c.bg3, bg = c.bg_deep },
     SnacksPickerTitle       = { fg = c.ember, bold = true },
     SnacksPickerBoxTitle    = { fg = c.ember, bold = true },
-    SnacksPickerInput       = { fg = c.fg, bg = c.bg_deep },
-    SnacksPickerInputBorder = { fg = c.bg3, bg = c.bg_deep },
     SnacksPickerInputTitle  = { fg = c.ember, bold = true },
-    SnacksPickerList        = { fg = c.fg, bg = c.bg_deep },
-    SnacksPickerListBorder  = { fg = c.bg3, bg = c.bg_deep },
-    SnacksPickerPreview     = { fg = c.fg, bg = c.bg_deep },
-    SnacksPickerPreviewBorder = { fg = c.bg3, bg = c.bg_deep },
     SnacksPickerMatch       = { fg = c.ember, bold = true },
     SnacksPickerDir         = { fg = c.comment },
     SnacksPickerFile        = { fg = c.fg },
@@ -83,11 +83,7 @@ function M.get(c)
     BlinkCmpGhostText      = { fg = c.gutter, italic = true },
 
     -- fzf-lua
-    FzfLuaNormal      = { fg = c.fg, bg = c.bg_deep },
-    FzfLuaBorder      = { fg = c.bg3, bg = c.bg_deep },
     FzfLuaTitle       = { fg = c.ember, bold = true },
-    FzfLuaPreviewNormal = { fg = c.fg, bg = c.bg_deep },
-    FzfLuaPreviewBorder = { fg = c.bg3, bg = c.bg_deep },
     FzfLuaCursorLine  = { bg = c.bg2 },
     FzfLuaFzfMatch    = { fg = c.ember, bold = true },
     FzfLuaHeaderText  = { fg = c.cinder },
@@ -95,8 +91,6 @@ function M.get(c)
 
     -- which-key
     WhichKey          = { fg = c.ember },
-    WhichKeyNormal    = { fg = c.fg, bg = c.bg_deep },
-    WhichKeyBorder    = { fg = c.bg3, bg = c.bg_deep },
     WhichKeyTitle     = { fg = c.ember, bold = true },
     WhichKeyGroup     = { fg = c.frost },
     WhichKeyDesc      = { fg = c.fg },
@@ -105,16 +99,9 @@ function M.get(c)
     WhichKeyIcon      = { fg = c.brass },
 
     -- noice
-    NoiceCmdline          = { fg = c.fg, bg = c.bg_deep },
-    NoiceCmdlinePopup     = { fg = c.fg, bg = c.bg_deep },
-    NoiceCmdlinePopupBorder = { fg = c.bg3, bg = c.bg_deep },
     NoiceCmdlinePopupTitle = { fg = c.ember, bold = true },
     NoiceCmdlineIcon      = { fg = c.ember },
     NoiceCmdlineIconSearch = { fg = c.brass },
-    NoiceConfirm          = { fg = c.fg, bg = c.bg_deep },
-    NoiceConfirmBorder    = { fg = c.bg3, bg = c.bg_deep },
-    NoicePopup            = { fg = c.fg, bg = c.bg_deep },
-    NoicePopupBorder      = { fg = c.bg3, bg = c.bg_deep },
     NoiceMini             = { fg = c.fg_dim, bg = c.bg1 },
     NoiceVirtualText      = { fg = c.gutter, italic = true },
     NoiceLspProgressTitle = { fg = c.fg },

--- a/lua/cendre/groups/lsp.lua
+++ b/lua/cendre/groups/lsp.lua
@@ -44,7 +44,6 @@ function M.get(c)
     LspInlayHint      = { fg = c.gutter, bg = c.bg1, italic = true },
     LspCodeLens       = { fg = c.comment, italic = true },
     LspCodeLensSeparator = { fg = c.bg3 },
-    LspInfoBorder     = { fg = c.bg3, bg = c.bg_deep },
 
     -- semantic tokens: follow the same role mapping as treesitter
     ["@lsp.type.class"]         = { fg = c.frost },

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -87,6 +87,65 @@ check("transparent = true keeps the float border stroke", function()
   assert(hl.fg ~= nil, "FloatBorder lost its stroke")
 end)
 
+check("no group repeats a float surface, so plugin windows can inherit it", function()
+  reload()
+  local c = require("cendre.palette").get("hard")
+  local built = {}
+  for _, mod in ipairs({ "editor", "syntax", "treesitter", "lsp", "integrations" }) do
+    for name, hl in pairs(require("cendre.groups." .. mod).get(c)) do built[name] = hl end
+  end
+
+  -- A group that copies NormalFloat or FloatBorder renders identically and buys
+  -- nothing, because every plugin already links its window to those two. What it
+  -- does buy is a pinned colour, which `transparent = true` cannot strip: that is
+  -- what used to leave which-key, the Snacks picker, Noice and fzf-lua opaque over
+  -- the terminal. Colour the two surfaces, and the windows follow.
+  local function signature(hl)
+    local parts = {}
+    for _, key in ipairs({ "fg", "bg", "sp", "bold", "italic", "underline", "reverse" }) do
+      if hl[key] ~= nil then
+        parts[#parts + 1] = key .. "=" .. tostring(hl[key])
+      end
+    end
+    return table.concat(parts, " ")
+  end
+
+  local surfaces = { NormalFloat = true, FloatBorder = true }
+  -- these two carry bg_deep against a bg0 fallback, so they say something the
+  -- surface groups do not
+  local allowed = { SnacksNormal = true, SnacksNormalNC = true, NeoTreeWinSeparator = true }
+  for name, hl in pairs(built) do
+    if not surfaces[name] and not allowed[name] then
+      for surface in pairs(surfaces) do
+        assert(signature(hl) ~= signature(built[surface]),
+          name .. " is a verbatim copy of " .. surface ..
+          ", which pins a colour transparent = true then cannot strip")
+      end
+    end
+  end
+end)
+
+check("transparent = true leaves no window surface painted", function()
+  reload()
+  require("cendre").setup({ transparent = true })
+  require("cendre").load()
+  local c = require("cendre.palette").get("hard")
+  local grounds = {}
+  for _, key in ipairs({ "bg_deep", "bg0" }) do
+    grounds[tonumber(c[key]:sub(2), 16)] = key
+  end
+
+  -- Anything a plugin points a window at ends in one of these. A ground colour
+  -- surviving here means the reader asked to see their terminal and got a panel.
+  for name, hl in pairs(vim.api.nvim_get_hl(0, {})) do
+    if hl.bg and grounds[hl.bg] and
+      (name:match("Normal$") or name:match("NormalNC$") or name:match("Float$")
+       or name:match("Border$") or name:match("Popup$") or name:match("Cmdline$")) then
+      error(name .. " still paints " .. grounds[hl.bg] .. " under transparent = true")
+    end
+  end
+end)
+
 check("transparent = false keeps Normal bg", function()
   reload()
   require("cendre").setup({ background = "hard", transparent = false })


### PR DESCRIPTION
With `transparent = true`, which-key, the Snacks picker, Noice and fzf-lua stayed opaque rectangles over the terminal. Everything else went through.

## Why

The switch worked from a hand written list of 24 group names in `init.lua`. The theme defines 245 groups. A list cannot follow that, and it did not: the picker alone has ten.

The deeper cause is the opposite of what it looks like. Sora, which behaves correctly here, defines **fewer** groups, 187, and none of those windows at all. They fall back to `NormalFloat`, which its list does strip, so they go transparent for free. Cendre named them explicitly and pinned each one to `bg_deep`, and a pinned colour is one the switch cannot strip. The more thorough coverage is what broke the option.

## What changed

Twenty two of those groups repeated `NormalFloat` or `FloatBorder` **verbatim**, field for field:

```
WhichKeyNormal, WhichKeyBorder
SnacksPicker, Border, Input, InputBorder, List, ListBorder, Preview, PreviewBorder
NoiceCmdline, CmdlinePopup, CmdlinePopupBorder, Confirm, ConfirmBorder, Popup, PopupBorder
FzfLuaNormal, Border, PreviewNormal, PreviewBorder
LspInfoBorder
```

They rendered identically to the two surfaces they copied, so they bought nothing. They are gone, and each plugin now links its own window to `NormalFloat` and its edge to `FloatBorder`, which is what those plugins do by default. The opaque mode looks the same, the transparent mode works, and plugins released after this file are covered without touching it.

Three groups that also matched by value were kept, because their fallback is not a float surface: `SnacksNormal`, `SnacksNormalNC` and `NeoTreeWinSeparator` carry `bg_deep` where `Normal` and `WinSeparator` carry `bg0`, so they do say something.

Everything a plugin colours differently from a plain float stayed: `WhichKeyDesc`, `SnacksPickerMatch`, `NoiceCmdlineIcon`, the titles, the paths, the separators. Those are the value.

## The completion menu stays painted

`Pmenu` and the Blink windows sit on `bg1`, not `bg_deep`, and they keep their background. A transparent completion popup over code is not readable. Sora keeps it painted too.

## What holds the line

Two assertions, both verified by reintroducing the bug:

```
FAIL - no group repeats a float surface: WhichKeyNormal is a verbatim copy of
       NormalFloat, which pins a colour transparent = true then cannot strip
FAIL - transparent = true leaves no window surface painted: WhichKeyNormal still
       paints bg_deep under transparent = true
```

## Worth an eye before merging

The opaque rendering now depends on each plugin linking its window to `NormalFloat`, which is the convention and what sora relies on today. It is not something a headless test can prove. Open which-key, the picker, `:` for the Noice cmdline and an LSP hover, in both modes, and check that nothing lost its border or its surface.