### PR TITLE
fix(site): give the toolbar controls one declared height

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -60,6 +60,7 @@
   --mono: "SF Mono", SFMono-Regular, ui-monospace, Menlo, "DejaVu Sans Mono", monospace;
   --serif: Charter, "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
   --pad: clamp(1.25rem, 4.5vw, 4.5rem);
+  --ctl-h: 1.75rem;
 }
 
 /* Depth moves the ground and nothing else, so a screenshot at any depth is
@@ -224,26 +225,32 @@ code { font-family: var(--mono); font-size: 0.92em; color: var(--ink2); }
   text-transform: uppercase; font-size: 0.62rem;
 }
 .seg input { position: absolute; opacity: 0; pointer-events: none; }
-.seg label {
-  font-size: 0.64rem; letter-spacing: 0.1em; text-transform: uppercase;
-  cursor: pointer; border: 1px solid var(--rule);
-  color: var(--ink3); padding: 0.28rem 0.55rem;
+
+/* The two controls in the toolbar, written once because they are the same control.
+   Their height is declared rather than left to fall out of their contents: the
+   switcher used to take it from the body's line-height and the star box from the
+   star glyph, so the two never agreed, and a star count arriving later would have
+   moved one of them again. */
+.seg label, .bar-gh {
+  height: var(--ctl-h); line-height: 1;
+  display: inline-flex; align-items: center;
+  font-size: 0.64rem; text-transform: uppercase;
+  color: var(--ink3); border: 1px solid var(--rule);
 }
+.seg label:hover, .bar-gh:hover { color: var(--ink); }
+
+.seg label { letter-spacing: 0.1em; cursor: pointer; padding-inline: 0.55rem; }
 .seg input + label:not(:first-of-type) { border-inline-start: 0; }
-.seg label:hover { color: var(--ink); }
 .seg input:checked + label {
   color: var(--g0); background: var(--ember); border-color: var(--ember);
 }
 .seg input:focus-visible + label { outline: 2px solid var(--ember); outline-offset: 2px; }
 
 .bar-gh {
-  justify-self: end; display: flex; align-items: center; gap: 0.4rem;
-  text-decoration: none; color: var(--ink3);
-  font-size: 0.64rem; letter-spacing: 0.14em; text-transform: uppercase;
-  border: 1px solid var(--rule); padding: 0.33rem 0.6rem;
-  line-height: 1;
+  justify-self: end; gap: 0.4rem; text-decoration: none;
+  letter-spacing: 0.14em; padding-inline: 0.6rem;
 }
-.bar-gh:hover { color: var(--ink); border-color: var(--ink3); }
+.bar-gh:hover { border-color: var(--ink3); }
 /* The glyph is set above the words and its line-height pulled back by the same
    factor, so it reads as an icon without dragging the box taller than a label. */
 .bar-gh .star {
@@ -258,11 +265,13 @@ code { font-family: var(--mono); font-size: 0.92em; color: var(--ink2); }
 .bar-gh.has-count .w-on, .bar-gh.has-count .w-gh { display: none; }
 
 @media (max-width: 560px) {
+  /* taller on a phone, where these are tap targets rather than click targets */
+  :root { --ctl-h: 2rem; }
   .bar-in { gap: 0.45rem; }
   .bar-mark { letter-spacing: 0.16em; }
   .seg legend { display: none; }
-  .seg label { padding: 0.45rem 0.42rem; letter-spacing: 0.06em; }
-  .bar-gh { letter-spacing: 0.04em; font-size: 0.6rem; gap: 0.25rem; padding: 0.45rem 0.5rem; }
+  .seg label { padding-inline: 0.42rem; letter-spacing: 0.06em; }
+  .bar-gh { letter-spacing: 0.04em; font-size: 0.6rem; gap: 0.25rem; padding-inline: 0.5rem; }
   .bar-gh:not(.has-count) .w-stars, .bar-gh:not(.has-count) .w-on { display: none; }
 }
 @media (max-width: 360px) {


### PR DESCRIPTION
The depth switcher and the star box in the toolbar were never the same height.

```
             switcher   star box   gap
desktop        27.31      24.00    3.31px
phone          32.75      27.84    4.91px
```

## Why

Neither control decided its own height. The switcher had no `line-height`, so it inherited the body 1.6 and got a 16.38px line box. The star box declared `line-height: 1`, but its height did not come from its text either: the star glyph is 11.47px, taller than the 10.24px line, and a flex line is as tall as its tallest item.

Three sources for one height, and none of them was the stylesheet.

## What changed

Both read a single `--ctl-h`, with `padding-inline` only and `line-height: 1`:

```css
:root { --ctl-h: 1.75rem; }
@media (max-width: 560px) { :root { --ctl-h: 2rem; } }
```

That matters beyond the alignment. The box reads `0` today and will read four digits eventually, and under the old rules a wider number could have changed the height again. Now nothing inside can.

The phone keeps a taller control on purpose, 32px against 28px: there they are tap targets.

They are also written as one rule now, because they shared six declarations and are the same kind of control. The state rules still win over it: `:checked` keeps its ember fill, the segments still collapse their shared border to a single stroke, and the focus outline is unchanged.

## Measured

```
320 to 1440px    gap 0.00px, identical top and bottom, aligned to the pixel
                 label text centred to within 0.25px
                 the BACKGROUND legend still 0.00px off the switcher centre
                 horizontal overflow 0px
checked state    bg ember, text on the ground colour, border ember
segment borders  1px, 0, 0 with 0.00px between boxes, so one stroke between two
```

The star sits 2px off the geometric centre, and that is deliberate: its `translateY(-1px)` optical nudge was measured earlier. The glyph reads centred, its metrics are not.

Nothing else moved: `tsc --strict` on the page script stays clean, `html-validate` reports the same four pre-existing findings, no CSS selector went dead, and no rule declares a property twice.