### PR TITLE
fix(extras): carry the licence beside the Zed manifest

### DIFF
--- a/extras/zed/LICENSE
+++ b/extras/zed/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 aejkatappaja
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lua/cendre/extras/editors.lua
+++ b/lua/cendre/extras/editors.lua
@@ -261,6 +261,18 @@ end
 
 --- @param bg string
 --- @return string
+--- The licence, copied beside the Zed manifest. Their packaging step reads it from
+--- the extension directory rather than from the repository root, which with a path
+--- field means extras/zed and not here, so the copy is required and it is read from
+--- the root file rather than retyped, which is what stops the two from diverging.
+--- @return string
+function M.zed_licence()
+  local fd = assert(io.open("LICENSE", "r"), "LICENSE is missing from the repository root")
+  local body = fd:read("*a")
+  fd:close()
+  return body
+end
+
 --- The Zed extension manifest. One for the three themes, since Zed lists an
 --- extension once and its themes inside it.
 ---

--- a/lua/cendre/extras/init.lua
+++ b/lua/cendre/extras/init.lua
@@ -59,6 +59,9 @@ local ONCE = {
   -- Zed lists an extension once and its themes inside it, so the manifest does
   -- not take a depth suffix even though the three themes beside it do.
   ["extras/zed/extension.toml"] = editors.zed_extension,
+  -- their packaging step looks for the licence beside the manifest, not at the
+  -- root of the repository, so the extension carries its own copy
+  ["extras/zed/LICENSE"] = editors.zed_licence,
 
   ["assets/banner.svg"] = art.banner,
   ["assets/editor.svg"] = art.editor,


### PR DESCRIPTION
The submission to `zed-industries/extensions` failed their packaging check:

```
Packaging cendre-theme. Version: 0.1.0
Checking out Git submodule at extensions/cendre-theme
Error: No license was found.
```

Which is surprising, since this repository has an MIT `LICENSE` at its root.

## Why it happened

Their `package-extensions.js` calls `retrieveLicenseCandidates(extensionPath)`, and `extensionPath` already includes the `path` field. With `path = "extras/zed"` it therefore reads `extras/zed/`, not the root of the submodule.

Their documentation says "your license file should be at the root of your extension repository", which is written for the usual case where the whole repository is the extension. With a monorepo `path`, the root of the extension is the path.

## The fix

`extras/zed/LICENSE` is now generated, by reading the root `LICENSE` rather than retyping its text. So there is one licence in this repository and the copy cannot drift from it, and the drift check covers it like every other generated file.

Verified byte for byte against the root file.