### PR TITLE
ci: keep the Obsidian theme repository in step with the palette

### DIFF
--- a/.github/workflows/sync-obsidian.yml
+++ b/.github/workflows/sync-obsidian.yml
@@ -1,0 +1,62 @@
+name: sync-obsidian
+
+# Obsidian's registry points at a repository, never at a path inside one, and every
+# theme in it keeps theme.css at its root. So unlike Zed, which reads this repo
+# directly through a path field, Obsidian needs a second repository, and a second
+# repository means a copy. This keeps that copy an output of the generator rather
+# than something somebody remembers to update.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stamp the released version into the manifest
+        run: |
+          set -euo pipefail
+          # read from the release manifest rather than the tag, so a manual run
+          # produces the same result as a published release
+          version=$(jq -r '.["."]' .release-please-manifest.json)
+          echo "version=$version" >> "$GITHUB_ENV"
+
+          mkdir -p out
+          cp extras/obsidian/cendre/theme.css out/theme.css
+          cp LICENSE out/LICENSE
+          jq --arg v "$version" '.version = $v' \
+            extras/obsidian/cendre/manifest.json > out/manifest.json
+
+          echo "Syncing cendre $version"
+          cat out/manifest.json
+
+      - name: Push to the theme repository
+        env:
+          GH_TOKEN: ${{ secrets.OBSIDIAN_SYNC_TOKEN }}
+        run: |
+          set -euo pipefail
+          git clone --depth 1 \
+            "https://x-access-token:${GH_TOKEN}@github.com/Aejkatappaja/cendre-obsidian.git" theme
+          # only the three generated files are replaced: the screenshot and the
+          # readme live in that repository and are not ours to overwrite
+          cp out/theme.css out/manifest.json out/LICENSE theme/
+
+          cd theme
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet; then
+            echo "Already in step with cendre $version, nothing to push"
+            exit 0
+          fi
+
+          git add theme.css manifest.json LICENSE
+          git commit -m "Sync cendre $version"
+          git push

--- a/extras/obsidian/cendre-medium/manifest.json
+++ b/extras/obsidian/cendre-medium/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "cendre-medium",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "minAppVersion": "1.0.0",
   "author": "Aejkatappaja",
   "authorUrl": "https://github.com/Aejkatappaja/cendre"

--- a/extras/obsidian/cendre-soft/manifest.json
+++ b/extras/obsidian/cendre-soft/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "cendre-soft",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "minAppVersion": "1.0.0",
   "author": "Aejkatappaja",
   "authorUrl": "https://github.com/Aejkatappaja/cendre"

--- a/extras/obsidian/cendre/manifest.json
+++ b/extras/obsidian/cendre/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "cendre",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "minAppVersion": "1.0.0",
   "author": "Aejkatappaja",
   "authorUrl": "https://github.com/Aejkatappaja/cendre"

--- a/lua/cendre/extras/tools.lua
+++ b/lua/cendre/extras/tools.lua
@@ -832,11 +832,18 @@ function M.obsidian(bg)
 ]]):format(bg, LINK, h, s, l, channels(c.error),
     table.concat(rows, "\n"), table.concat(edit, "\n\n"))
 end
+--- The Obsidian manifest. Its version reads 0.0.0 here on purpose: Obsidian compares
+--- it against the installed copy to offer an update, so it has to follow the releases,
+--- and the sync workflow stamps the released number in as it pushes. Reading
+--- .release-please-manifest.json here instead would fail the drift check on every
+--- release pull request, which bumps that manifest without re-rendering this file.
+--- @param bg string
+--- @return string
 function M.obsidian_manifest(bg)
   return ([[
 {
   "name": "%s",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "minAppVersion": "1.0.0",
   "author": "Aejkatappaja",
   "authorUrl": "%s"


### PR DESCRIPTION
Obsidian needs a second repository, and this stops that repository from becoming a copy nobody regenerates.

## Why a second repository at all

Their registry entry has exactly these keys, and none of them is a path:

```json
{ "name": "Sora", "author": "aejkatappaja", "repo": "aejkatappaja/sora-obsidian",
  "screenshot": "screenshot.jpg", "modes": ["dark"] }
```

Sampled across their list, every modern theme keeps `theme.css` at its repository root, and the few exceptions keep `obsidian.css` there. So the files cannot live in `extras/obsidian/`, unlike Zed which reads this repo directly through its `path` field and therefore has nothing to synchronise.

## Why automate it

`sora-theme` is what a hand-kept copy becomes: a Zed theme with no relationship to sora s palette, frozen at 0.1.0 while sora is at 1.5.0, and nothing to tell you it has gone stale. The Obsidian theme here is generated and drift-checked, and it should stay that way after it is published.

On every published release, and on demand through `workflow_dispatch`, the workflow pushes `theme.css`, `manifest.json` and `LICENSE` into `Aejkatappaja/cendre-obsidian`. It touches nothing else: the screenshot and the readme live in that repository.

It also exits without a commit when nothing changed, so a release that did not touch the theme leaves no empty commit behind.

## The manifest version

Obsidian compares the manifest version against the installed copy to decide whether to offer an update, so it has to follow the releases. It cannot be rendered by the generator: the release pull request bumps `.release-please-manifest.json` without re-rendering, and the drift check would fail on every release, exactly as it would have for the Zed manifest.

So the generator emits `0.0.0` and the workflow stamps the released number in as it pushes, reading `.release-please-manifest.json` rather than the tag, which makes a manual run behave like a real release. Simulated locally:

```
version read: 1.3.0
{ "name": "cendre", "version": "1.3.0", "minAppVersion": "1.0.0",
  "author": "Aejkatappaja", "authorUrl": "https://github.com/Aejkatappaja/cendre" }
```

## Before it can run

Two things this pull request cannot do:

- `Aejkatappaja/cendre-obsidian` has to exist, with a screenshot at its root.
- `OBSIDIAN_SYNC_TOKEN` has to be set as a repository secret, with write access to that repository. `gh secret set OBSIDIAN_SYNC_TOKEN --repo Aejkatappaja/cendre` reads it from a prompt, so it never lands in a shell history.

Until both exist the workflow simply fails on the release, which is visible rather than silent.

## One limitation worth stating

Obsidian lists one theme per repository, so `cendre-obsidian` carries the `hard` depth. `medium` and `soft` stay installable by copying them out of `extras/obsidian/`, which is what the site already tells a reader to do.