### PR TITLE
fix(ci): run the Obsidian sync inside the release job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,56 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # The Obsidian theme lives in its own repository, because their registry
+      # points at a repository and never at a path inside one. Pushing it from here
+      # rather than from an `on: release` workflow is not a preference: release-please
+      # publishes the release with GITHUB_TOKEN, and GitHub refuses to let an event
+      # raised by that token start another workflow, so a release trigger never fires.
+      # Running in this same job sidesteps that, because nothing new is triggered.
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Stamp the released version into the Obsidian manifest
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          cp extras/obsidian/cendre/theme.css out/theme.css
+          cp LICENSE out/LICENSE
+          jq --arg v "$VERSION" '.version = $v' \
+            extras/obsidian/cendre/manifest.json > out/manifest.json
+          echo "Syncing cendre $VERSION"
+          cat out/manifest.json
+
+      - name: Push to the Obsidian theme repository
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ secrets.OBSIDIAN_SYNC_TOKEN }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          git clone --depth 1 \
+            "https://x-access-token:${GH_TOKEN}@github.com/Aejkatappaja/cendre-obsidian.git" theme
+          # only the three generated files are replaced: the screenshot and the
+          # readme live in that repository and are not ours to overwrite
+          cp out/theme.css out/manifest.json out/LICENSE theme/
+
+          cd theme
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet; then
+            echo "Already in step with cendre $VERSION, nothing to push"
+            exit 0
+          fi
+
+          git add theme.css manifest.json LICENSE
+          git commit -m "Sync cendre $VERSION"
+          git push

--- a/.github/workflows/sync-obsidian.yml
+++ b/.github/workflows/sync-obsidian.yml
@@ -6,9 +6,11 @@ name: sync-obsidian
 # repository means a copy. This keeps that copy an output of the generator rather
 # than something somebody remembers to update.
 
+# Manual only. A release trigger would never fire: release-please publishes with
+# GITHUB_TOKEN, and GitHub refuses to let an event raised by that token start
+# another workflow, so the sync runs inside the release-please job instead. This
+# stays for re-pushing a release by hand, and for testing the token.
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The sync I added yesterday never ran. 1.4.0 published and nothing reached `cendre-obsidian`.

## Why

```
12:49:05  release-please  push     success
12:49:05  CI              push     success
12:41:25  sync-obsidian   workflow_dispatch  success   <- my manual test, the only run
```

No run for the release event at all. The release is published by `github-actions[bot]`, and GitHub refuses to let an event raised by `GITHUB_TOKEN` start another workflow. `on: release: types: [published]` therefore cannot fire here.

This is the same guard that leaves the CI on every release pull request sitting in `action_required` until it is approved by hand. I had already diagnosed that one and did not carry it over to this workflow, which is my mistake.

## The fix

The sync runs as steps of the release-please job, conditional on its `release_created` output. Nothing new is triggered, so nothing is held back. The version comes from the action s `version` output rather than from `.release-please-manifest.json` on disk: same number, one fewer file to read, and it is the value the release actually carries.

`sync-obsidian.yml` keeps `workflow_dispatch`. It is still useful for re-pushing a release by hand, and it is how the token gets exercised without waiting for a release.

## The token is still untested

My manual run earlier reported `Already in step with cendre 1.3.0, nothing to push`, because I had populated that repository by hand minutes before with identical content. So the clone happened, which proves nothing since the repository is public and clones without credentials, and the push path was never reached.

After this merges, `gh workflow run sync-obsidian.yml` will find 1.4.0 against the 1.3.0 sitting in the theme repository and actually push. That is the first real test.