### PR TITLE
feat(ci): cut an Obsidian release on every version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -66,3 +66,23 @@ jobs:
           git add theme.css manifest.json LICENSE
           git commit -m "Sync cendre $VERSION"
           git push
+
+      # Obsidian offers an update by comparing the version in a release asset, so
+      # a version without a release never reaches anybody who already installed the
+      # theme. The tag carries no v prefix, which is the shape their directory reads.
+      - name: Release the Obsidian theme
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ secrets.OBSIDIAN_SYNC_TOKEN }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          repo=Aejkatappaja/cendre-obsidian
+          if gh release view "$VERSION" --repo "$repo" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists on $repo"
+            exit 0
+          fi
+          gh release create "$VERSION" --repo "$repo" \
+            --title "$VERSION" \
+            --notes "cendre $VERSION for Obsidian. Generated from the palette in Aejkatappaja/cendre." \
+            out/manifest.json out/theme.css


### PR DESCRIPTION
Pushing the theme to the default branch turns out not to be enough.

## What I had wrong

Obsidian no longer takes theme submissions as a pull request to `obsidian-releases`. I checked before opening one:

```
obsidianmd/obsidian-releases   issues: false   merged pull requests: 0
```

Their two template links, `?template=plugin.md` and `?template=theme.md`, point at files that no longer exist. Submission now happens at community.obsidian.md, signed in with GitHub, and it requires a **GitHub release with `manifest.json` and `theme.css` attached as assets**, on a tag matching the manifest version.

That is not just a submission formality. The directory decides whether to offer an update by reading the version out of a release asset, so a version that ships without a release never reaches anybody who already installed the theme.

## The step

Attaches both files to a tag with no `v` prefix, which is the shape their directory reads and what `sora-obsidian` already uses:

```
sora-obsidian   tag 1.0.0   assets: manifest.json, theme.css
cendre-obsidian tag 1.4.1   assets: manifest.json, theme.css
```

It exits quietly when the release already exists, so a re-run does not fail the job.

## Also done by hand, outside this pull request

`cendre-obsidian` was missing things their documentation asks for, and they are in place now:

- the 1.4.1 release, with both assets
- the screenshot resized to **512 x 288**, which is what they recommend and what sora ships. It was 2000 x 1382. Nothing is legible at that size, on any theme in their directory, so the readme points at a 1024 wide copy instead
- the screenshot shown in the readme, which it was not

## What is left for you

The submission itself, which needs your GitHub sign-in and cannot be scripted: community.obsidian.md, "New theme", the repository URL.