### PR TITLE
chore: add the community health files, and one dependabot ecosystem

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: A colour, a highlight group or a generated file is wrong
+labels: ["bug"]
+assignees: ["Aejkatappaja"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Screenshots help more than descriptions here. A colour is easier to see
+        than to name.
+
+  - type: input
+    id: where
+    attributes:
+      label: Where
+      description: Neovim, or which surface under `extras/`
+      placeholder: Neovim, or yazi, or hunk, or Ghostty
+    validations:
+      required: true
+
+  - type: dropdown
+    id: depth
+    attributes:
+      label: Depth
+      options: ["hard", "medium", "soft"]
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected, and what you got
+      description: |
+        If you know the highlight group, `:Inspect` under the cursor names it and
+        the colour it resolved to. Paste that if you have it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: A file that shows it
+      description: |
+        The smallest snippet where the colour is wrong, and its language. A
+        colour that only goes wrong in one grammar is a different bug from one
+        that goes wrong everywhere.
+      render: text
+
+  - type: input
+    id: version
+    attributes:
+      label: Versions
+      description: cendre, Neovim, and the tool if this is not about the editor
+      placeholder: cendre 1.6.0, nvim 0.11.2, yazi 26.5.6
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before opening this
+      options:
+        - label: "`termguicolors` is set and the terminal does true colour"
+          required: true
+        - label: No `on_colors` or `on_highlights` hook is changing this
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question, or a colour you would argue about
+    url: https://github.com/Aejkatappaja/cendre/discussions
+    about: Taste is a discussion, not a bug. Every hue here was computed, so the interesting arguments are about lightness and chroma.
+  - name: How a hue was derived
+    url: https://cendretheme.com/#derivation
+    about: Each pigment traced from its emission wavelength to its hex, step by step.
+  - name: Report a security issue
+    url: https://github.com/Aejkatappaja/cendre/security/advisories/new
+    about: Privately, not as an issue. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/surface_request.yml
+++ b/.github/ISSUE_TEMPLATE/surface_request.yml
@@ -1,0 +1,58 @@
+name: New surface
+description: Ask for a tool cendre does not theme yet
+title: "Surface: "
+labels: ["enhancement", "extras"]
+assignees: ["Aejkatappaja"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Every surface is rendered from `lua/cendre/palette.lua`, so what decides
+        whether one can be added is whether the tool documents its theme format.
+        The links below are the whole ask.
+
+  - type: input
+    id: tool
+    attributes:
+      label: Tool
+      placeholder: yazi, Zellij, Neovide
+    validations:
+      required: true
+
+  - type: input
+    id: schema
+    attributes:
+      label: Where its theme format is documented
+      description: |
+        A docs page, or better, the file in its source that lists every key it
+        reads. That list is what gets covered, and a docs page can be behind it.
+      placeholder: https://...
+    validations:
+      required: true
+
+  - type: input
+    id: install
+    attributes:
+      label: Where the file has to land
+      placeholder: ~/.config/tool/themes/
+    validations:
+      required: true
+
+  - type: textarea
+    id: name
+    attributes:
+      label: Does it store a theme name
+      description: |
+        If the file carries its own name rather than taking it from its filename,
+        say so. Three depths ship for every surface, and they collide on one
+        entry unless the name is qualified.
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else
+      description: |
+        Whether it reloads live, whether it needs a cache rebuilt, whether it
+        ignores keys it does not know. The last one matters most: a tool that
+        stays quiet about an unknown key is a tool where a half-applied theme
+        looks fine.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+# Only one ecosystem is listed, because only one exists here. There is no
+# package.json, no Cargo.toml and no lockfile: this is Lua with no dependencies.
+# What does have pinned versions is the three actions the workflows call, and
+# those are worth keeping current.
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels: ["ci"]
+    assignees: ["Aejkatappaja"]
+    commit-message:
+      # release-please reads these, so they follow the same convention as
+      # everything else. A bumped action changes no colour, so it is a chore.
+      prefix: "chore(ci)"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+## What this changes
+
+<!-- One or two sentences. What is different after this lands, and why. -->
+
+## Commit messages
+
+This repository uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/),
+`type(scope): subject`, because release-please reads them to build the changelog
+and pick the next version. `feat` and `fix` produce a changelog entry, the rest
+do not.
+
+Scopes in use: `palette`, `groups`, `extras`, `lualine`, `site`, `ci`.
+
+- [ ] Every commit follows `type(scope): subject`
+
+## If this touches colours
+
+- [ ] Nothing under `extras/`, `assets/` or `docs/` was edited by hand. All 87
+      of those files are rendered from `lua/cendre/palette.lua`, and the test
+      fails on any difference
+- [ ] Regenerated with the command in `CONTRIBUTING.md`, and the regenerated
+      files are committed
+- [ ] Every colour comes from the palette. Nothing hardcoded, nothing blended
+
+## If this adds highlight groups
+
+- [ ] The role map holds: keywords `cinder`, functions `brass`, literals `sap`,
+      types `frost`, properties and parameters `ember`. Declared names stay in
+      `fg`, punctuation in `fg_dim`. See `:help cendre-roles`
+- [ ] Diagnostics use the semantic family, never a pigment
+- [ ] No plugin window repeats `NormalFloat` or `FloatBorder`. Link to them
+      instead, or `transparent = true` cannot reach it. There is a test for this
+- [ ] Nothing readable lands under 4.5:1, or it is stated rather than hidden
+
+## Verified
+
+- [ ] `smoke (stable)` and `smoke (nightly)` pass. Both are required to merge
+
+<!--
+Numbers in a description are worth more than adjectives. If you measured a
+contrast ratio, read a tool's schema, or proved a test fails without your fix,
+say so and show it.
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,89 @@
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, email **frank.refactored@gmail.com**. Reports are read in confidence. If your report is about the maintainer, say so and it will be handled by someone uninvolved.
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,118 @@
+# Contributing
+
+The one rule that will bite you if you skip it: **nothing under `extras/`,
+`assets/` or `docs/` is written by hand.** Those 87 files are rendered from
+`lua/cendre/palette.lua`, and the test fails on any difference. Edit the
+generator, not the output.
+
+## Run the test first
+
+```sh
+nvim --headless --noplugin -u NONE -c "set rtp+=." -c "luafile test/smoke.lua"
+```
+
+It exits non-zero on failure. `smoke (stable)` and `smoke (nightly)` are both
+required to merge, so a red test is not a review comment, it is a blocked branch.
+
+## Regenerate after touching a colour
+
+```sh
+nvim --headless --noplugin -u NONE -c "set rtp+=." -c "luafile scripts/extras.lua" -c q
+```
+
+Commit what it writes. A pull request that changes the palette without the
+regenerated files fails the drift check.
+
+## Commit messages
+
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/),
+`type(scope): subject`, in English. release-please reads them to build
+`CHANGELOG.md` and pick the next version, so the type is not decoration.
+
+`feat` and `fix` produce a changelog entry. `docs`, `test`, `refactor`, `ci` and
+`chore` do not, which is fine and often correct.
+
+Scopes in use:
+
+| scope | what it covers |
+| --- | --- |
+| `palette` | the derived colours in `lua/cendre/palette.lua` |
+| `groups` | highlight groups under `lua/cendre/groups/` |
+| `extras` | a generator under `lua/cendre/extras/`, and its output |
+| `lualine` | the lualine theme |
+| `site` | the landing page under `docs/` |
+| `ci` | workflows, checks, release tooling |
+
+Prefer several small commits to one large one. `Release-As:` in a footer forces a
+version when a release needs one.
+
+## Adding highlight groups
+
+Read `:help cendre-roles` first. The map is the whole design, and a group that
+ignores it will look wrong beside every other group:
+
+| pigment | role |
+| --- | --- |
+| `cinder` | keywords, control flow, storage |
+| `ember` | properties, fields, parameters, and the UI accent |
+| `brass` | functions, methods, calls |
+| `sap` | every literal value |
+| `frost` | types, classes, constructors, modules |
+
+Two rules that follow from it, both asserted by the test:
+
+- A declared name is not a role. Variables and constant names stay in `fg`, and
+  only the value a constant holds takes a pigment.
+- Punctuation is not a token. Operators, commas and brackets take `fg_dim`.
+
+Diagnostics are a separate family. `error` `warn` `ok` `hint` `info` all carry
+more chroma than any pigment, so a diagnostic never wears the same red as a
+keyword. Never reach for a pigment to signal a state.
+
+**Do not paint plugin windows.** which-key, the Snacks picker, Noice, fzf-lua and
+the rest link their windows to `NormalFloat` and their edges to `FloatBorder`.
+Colouring those two colours all of them, including plugins released after you
+read this. A verbatim copy of either group pins a colour that
+`transparent = true` then cannot strip, and there is a test that fails on it.
+
+Nothing readable goes under 4.5:1. Three colours do and are named in the README
+rather than hidden: `comment` everywhere, and `frost` and `error` at the `soft`
+depth. A fourth needs a reason and a line in the documentation.
+
+## Adding a surface
+
+Write a generator in the right module under `lua/cendre/extras/`, register it in
+`lua/cendre/extras/init.lua`, regenerate, and add a test that pins the tool's
+schema.
+
+That last part is the one worth insisting on. Every surface fixed so far was
+broken the same way: the tool ignored what it did not recognise instead of
+refusing it, so half a theme applied and nothing said which half. yazi silently
+dropped two retired sections, hunk silently dropped four keys that were never on
+its list. The drift check cannot catch that, because regenerating makes the file
+agree with itself.
+
+So find the list the tool's own code reads, not its documentation page. For yazi
+that was its shipped preset theme, for hunk a constant in its parser, for
+opencode a TypeScript type. Two of those three disagreed with the published docs.
+
+Then, if the tool stores a theme name rather than taking it from its filename,
+qualify it per depth, or `cendre` and `cendre-soft` installed together collide on
+one entry.
+
+## Colours
+
+Every hue was computed from a measurable property of a wood fire: Planck's law at
+1300 K for the coals, published emission wavelengths for the rest, through the
+CIE 1931 colour matching functions into OKLCH. Lightness and chroma are choices,
+because a spectral line sits far outside sRGB and has to be brought into gamut.
+
+A pull request that changes a hue needs to say where the new one comes from. That
+constraint is the project, not a formality. "It looks better" is a valid opinion
+and belongs in a
+[discussion](https://github.com/Aejkatappaja/cendre/discussions), where it may
+well win.
+
+## Licence
+
+MIT. By contributing you agree your work ships under it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security policy
+
+## Reporting
+
+Report privately, through
+[GitHub's advisory form](https://github.com/Aejkatappaja/cendre/security/advisories/new).
+Not as an issue, and not on the Reddit thread. Private vulnerability reporting is
+enabled on this repository, so that form reaches the maintainer and nobody else. If
+you would rather use email, **frank.refactored@gmail.com** reaches the same person.
+
+Expect a first reply within a week. If a report turns out to be real, the fix and
+the advisory go out together.
+
+## Supported versions
+
+The latest release only. This is a colorscheme with no dependencies and no
+runtime state, so there is nothing to backport a patch to: upgrading is reading
+one line in a plugin manager.
+
+| version | supported |
+| --- | --- |
+| latest release | yes |
+| anything older | no, upgrade |
+
+## What is actually worth reporting
+
+This repository is Lua that runs inside the reader's editor, plus three GitHub
+Actions workflows and one token. That is the whole surface, and it is small
+enough to name:
+
+- **Code execution.** `require("cendre")` runs on colorscheme load. Anything in
+  `lua/` that runs a shell command, reads a file outside the plugin, or opens a
+  socket does not belong there and is a real finding. The colorscheme reads no
+  file at runtime: `lua/cendre/extras/` is only ever executed by
+  `scripts/extras.lua`, by hand.
+- **A release that does not match this source.** The tag, the published files and
+  a fresh render of `lua/cendre/palette.lua` should agree. If they do not, say
+  so, whatever the cause.
+- **Anything reaching a workflow's write permissions or a secret.** The release
+  workflow pushes to a second repository with a scoped token. A way to make it
+  push somewhere else, or to print that token, is a real finding.
+- **A generated file that does not match the palette.** More likely a bug than an
+  attack, and the test catches it, but report it either way if you find one the
+  test misses.
+
+## What is not a vulnerability
+
+- A colour you dislike, or one that reads badly on your monitor. That is a
+  [discussion](https://github.com/Aejkatappaja/cendre/discussions).
+- A contrast ratio under 4.5:1 that the documentation already names. `comment`
+  everywhere, and `frost` and `error` at the `soft` depth, are deliberate and
+  stated in the README.
+- A Dependabot alert on a dependency. There are none: no `package.json`, no
+  `Cargo.toml`, no lockfile. If a tool tells you otherwise, it is looking at a
+  fork.


### PR DESCRIPTION
The five orange rows on the community profile, plus the one thing Dependabot can actually do here.

## Files

| file | note |
| --- | --- |
| `CODE_OF_CONDUCT.md` | Contributor Covenant **3.0** |
| `CONTRIBUTING.md` | generated files first, then Conventional Commits, the role map, adding a surface |
| `SECURITY.md` | the advisory form, which now works |
| `.github/pull_request_template.md` | conditional sections, Conventional Commits required |
| `.github/ISSUE_TEMPLATE/` | bug report, new surface, config |
| `.github/dependabot.yml` | `github-actions` only |

## Covenant 3.0, not 2.1

Taken verbatim from `EthicalSource/contributor_covenant` rather than from the rendered page, with the site's TOML frontmatter stripped and both placeholders filled. Attribution and CC BY-SA 4.0 untouched.

3.0 is not a cosmetic revision. `Enforcement Guidelines` becomes `Encouraged Behaviors` and `Restricted Behaviors`, and the four consequence tiers become a ladder with a repair path at each rung. Its enforcement note asks a project to edit that section if it has its own process; this one does not, so the ladder stands and the note comes out.

## Conventional Commits, documented as a requirement

release-please reads the type to build `CHANGELOG.md` and pick the version, so it is not a style preference. Both `CONTRIBUTING.md` and the pull request template say so, with the six scopes the history actually uses:

```
extras 14   site 4   ci 2   groups 2   palette 1   lualine 1
```

and a note that `feat` and `fix` reach the changelog while the rest do not.

## What the templates encode

The pull request template is split into conditional sections, so someone fixing a typo does not tick six boxes about colour. It names `smoke (stable)` and `smoke (nightly)` because those are the two the ruleset actually requires.

The bug report makes two boxes mandatory, both of which eliminate a false positive that would otherwise cost a round trip: a missing `termguicolors`, and an `on_colors` hook doing the thing being reported.

The new surface form makes the required field the location of the tool's theme format rather than the tool's name, and warns that a docs page can be behind the code. It also asks whether the tool ignores keys it does not recognise.

That last question is not hypothetical. It is the failure mode behind every surface fixed this week:

| tool | what was silently wrong |
| --- | --- |
| yazi | `[manager]` and `[select]` retired, ignored without a word |
| hunk | 20 of 33 keys inherited from `github-dark-default` |
| opencode | added and removed diff rows sharing one background |

`CONTRIBUTING.md` says to read the tool's own code rather than its documentation, and names where that list lives for each of the three. Two of those three documentation pages were behind the code.

## Dependabot

One ecosystem, because one exists. No `package.json`, no `Cargo.toml`, no lockfile, and the API reports zero open alerts. The three pinned actions are the only thing with a version to bump:

```
actions/checkout@v4
googleapis/release-please-action@v4
rhysd/action-setup-vim@v1
```

Weekly, labelled `ci`, prefixed `chore(ci)` so release-please keeps reading it.

CodeQL is deliberately absent: it supports none of this repository's four languages.

## Verified

Every issue template parses as YAML. Every path, command and help tag quoted in `CONTRIBUTING.md` exists, including `:help cendre-roles`. No em-dashes. `all checks passed`.
