### PR TITLE
fix(groups): make lazy.nvim's key hints readable in the tab they sit in

### DIFF
--- a/lua/cendre/groups/integrations.lua
+++ b/lua/cendre/groups/integrations.lua
@@ -155,8 +155,9 @@ function M.get(c)
     LazyH1           = { fg = c.bg0, bg = c.ember, bold = true },
     LazyH2           = { fg = c.ember, bold = true },
     LazyButton       = { fg = c.fg, bg = c.bg2 },
-    LazyButtonActive = { fg = c.bg0, bg = c.ember, bold = true },
-    LazySpecial      = { fg = c.frost },
+    -- lazy paints the key hint over this button, so the ground stays dark
+    LazyButtonActive = { fg = c.fg, bg = c.bg3, bold = true, underline = true },
+    LazySpecial      = { fg = c.ember },
     LazyCommit       = { fg = c.sap },
     LazyReasonPlugin = { fg = c.cinder },
     LazyReasonEvent  = { fg = c.brass },

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -375,6 +375,36 @@ check("the role map holds: every pigment lands where the page says", function()
   end
 end)
 
+check("a group drawn over a painted block reads against that block", function()
+  reload()
+  local c = require("cendre.palette").get("hard")
+  local built = {}
+  for _, mod in ipairs({ "editor", "syntax", "treesitter", "lsp", "integrations" }) do
+    for name, hl in pairs(require("cendre.groups." .. mod).get(c)) do built[name] = hl end
+  end
+
+  -- A foreground-only group stacked over a block another group already painted
+  -- never meets the editor ground, so nothing else here measures it.
+  local overlays = {
+    { "LazySpecial", { "LazyButtonActive", "LazyButton" } },
+  }
+
+  for _, pair in ipairs(overlays) do
+    local over = built[pair[1]]
+    assert(over and over.fg, pair[1] .. " has no foreground to check")
+    assert(not over.bg, pair[1] .. " carries a background, so it is not an overlay any more")
+
+    for _, name in ipairs(pair[2]) do
+      local under = built[name]
+      assert(under and under.bg, name .. " has no background to read against")
+      local r = ratio(over.fg, under.bg)
+      assert(r >= 4.5, string.format(
+        "%s is %.2f:1 over %s, which is the ratio a reader actually gets",
+        pair[1], r, name))
+    end
+  end
+end)
+
 check("nothing readable depends on bold or italic", function()
   reload()
   require("cendre").setup({ background = "hard", italic = false })


### PR DESCRIPTION
Reported in #34 as a nitpick about taste. It was the worst contrast ratio in the theme.

## What lazy actually does

It stacks `LazySpecial` over the button it has already painted, so the key hint inside a tab never meets the editor ground:

```lua
self:append(title, "LazyButtonActive", { wrap = true })
self:highlight({ ["%(.%)"] = "LazySpecial" })
```

`LazyButtonActive` was ember, `LazySpecial` was frost. The darkest pigment on a light ground.

| | before | after |
| --- | --- | --- |
| key hint, active tab | **1.70:1** | 4.74:1 |
| key hint, inactive tab | **3.30:1** | 5.63:1 |
| key hint, prose and bullets | 4.22:1 | 7.19:1 |
| active tab text | 7.19:1 | 7.51:1 |

The inactive one at 3.30:1 was not reported by anyone. Neither is among the three exceptions the rules name: the README licenses `frost` at the `soft` depth against the editor ground, not frost on ember.

## Before
<img width="1724" height="72" alt="CleanShot 2026-08-01 at 8  15 47@2x" src="https://github.com/user-attachments/assets/01d5abf8-451d-421b-a4da-3db216b554ed" />

## After
<img width="2946" height="112" alt="CleanShot 2026-08-01 at 7  57 58@2x" src="https://github.com/user-attachments/assets/2f981fc2-9a32-4551-bbe1-8b1b7b9dec4f" />



## The role error underneath

Frost means a container everywhere else here: `NeoTreeDirectoryName`, `NvimTreeFolderName`, `TroubleFile`, `NeotestNamespace`, `GrugFarResultsPath`, `WhichKeyGroup`. That is the coherent extension of its declared role, "types, classes, constructors, modules".

`LazySpecial` renders `(I)`, `<CR>` and the list bullets. A key to press is `ember`, and `WhichKey` two lines above already said so:

```lua
WhichKey      = { fg = c.ember }   -- a key
WhichKeyGroup = { fg = c.frost }   -- a container
WhichKeyIcon  = { fg = c.brass }   -- an icon
```

So the contrast number is the symptom. `LazySpecial = frost` was the mistake.

## Why the active tab is marked by weight and a rule

Once the ground has to be dark, something has to say which tab is open. Neither colour nor a lighter layer can, and both were measured before settling:

| ground for the active tab | step from bg2 | ember on it |
| --- | --- | --- |
| `bg_deep` | 1.28:1 | 7.85:1 |
| `bg0` | 1.21:1 | 7.19:1 |
| `bg3` | 1.16:1 | 4.74:1 |
| `bg4` | 1.46:1 | 3.68:1 |
| `bg5` | 1.96:1 | 2.76:1 |

No two layers differ by more than 1.96:1, and the one that does puts ember at 2.76:1. That finely stepped ramp is deliberate and documented, and it is what makes the ground unusable for signalling state. Ember against `fg` is only 1.59:1, so the text colour cannot do it either on a palette where every hue is warm.

A first attempt shipped `fg` on `bg3` with no rule. It was tested and rejected: the active tab became invisible at 1.16:1 against its neighbours. Weight and a rule carry it instead, which costs no contrast and leaves ember meaning exactly one thing.

`underline` has precedent here: `GrugFarResultsPath` and `TreesitterContextBottom` already use it.

## Not touched

`LazyH1` keeps its ember ground. It is the only group in lazy that gets painted without anything drawn over it, and lazy uses it for the home title rather than for an active tab, which is why the `lazy.nvim` pill still carries the accent.

## The test

Every contrast assertion in this repository measured a foreground against the editor ground. This pair never meets it, which is how 1.70:1 survived several releases.

The new check takes an overlay group and the blocks it can land on, and measures what a reader actually gets. It also asserts the overlay has no background of its own, since a group that does is not an overlay. Proven to fail on the old values:

```
FAIL - a group drawn over a painted block reads against that block:
  LazySpecial is 1.70:1 over LazyButtonActive, which is the ratio a reader actually gets
```

Verified on screen at every step, not only computed.
