### PR TITLE
docs: say why the cursor keeps the terminal's colour

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,32 @@ require("cendre").setup({
 })
 ```
 
+## The cursor stays your terminal's
+
+`Cursor`, `lCursor`, `CursorIM` and `TermCursor` are all set to `ember`, and outside
+`:terminal` Neovim never asks for them. Its default `'guicursor'` names a highlight
+group only for terminal mode:
+
+```
+n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20,t:block-blinkon500-blinkoff500-TermCursor
+```
+
+With no group on the other parts, the terminal draws its own cursor in its own
+colour. So a black cursor on this theme is your terminal's setting, not a missing
+highlight.
+
+The theme does not set `'guicursor'`, because that option carries the cursor's
+shape and blink rather than its colour, and those are yours.
+
+Two ways to change it. Install the terminal theme for whatever you run, and the
+cursor matches in the editor and in the shell, since every file under `extras/`
+sets it. Or hand the cursor to Neovim by naming the group on the other modes:
+
+```lua
+vim.opt.guicursor = "n-v-c-sm:block-Cursor,i-ci-ve:ver25-Cursor,"
+  .. "r-cr-o:hor20-Cursor,t:block-blinkon500-blinkoff500-TermCursor"
+```
+
 ## Palette
 
 Ground, hue 43°, which is wood ash under a 1300 K flame. Ash is spectrally flat,

--- a/doc/cendre.txt
+++ b/doc/cendre.txt
@@ -10,6 +10,7 @@ CONTENTS                                                     *cendre-contents*
   2. Requirements ............................. |cendre-requirements|
   3. Installation ............................. |cendre-installation|
   4. Configuration ............................ |cendre-configuration|
+     The cursor ............................... |cendre-cursor|
   5. Commands ................................. |cendre-commands|
   6. Depths ................................... |cendre-depths|
   7. Palette .................................. |cendre-palette|
@@ -136,6 +137,30 @@ Accepts a table. Every key is optional; pass only what you want to change.
                 hl["@keyword"] = { fg = c.brass, bold = true }
               end,
             })
+<
+                                                             *cendre-cursor*
+THE CURSOR
+
+|hl-Cursor|, |hl-lCursor|, |hl-CursorIM| and |hl-TermCursor| all carry the
+accent, and outside |:terminal| Neovim never asks for them. Its default
+'guicursor' names a highlight group only for terminal mode: >
+
+    n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20,
+    t:block-blinkon500-blinkoff500-TermCursor
+<
+With no group on the other parts, the terminal draws its own cursor in its own
+colour. A black cursor on this theme is the terminal's setting, not a missing
+highlight group.
+
+Cendre does not set 'guicursor'. That option carries the cursor's shape and
+its blink rather than its colour, and both are the reader's choice.
+
+To change it, either install the terminal theme for whatever you run, in
+which case the cursor matches in the editor and in the shell because every
+file under `extras/` sets it, or hand the cursor to Neovim: >lua
+
+    vim.opt.guicursor = "n-v-c-sm:block-Cursor,i-ci-ve:ver25-Cursor,"
+      .. "r-cr-o:hor20-Cursor,t:block-blinkon500-blinkoff500-TermCursor"
 <
 ==============================================================================
 5. COMMANDS                                                  *cendre-commands*


### PR DESCRIPTION
Someone on the launch thread thought their install was broken because their cursor stayed black. It was not.

## What actually happens

The four cursor groups are set:

```lua
Cursor     = { fg = c.bg0, bg = c.ember },
lCursor    = { fg = c.bg0, bg = c.ember },
CursorIM   = { fg = c.bg0, bg = c.ember },
TermCursor = { fg = c.bg0, bg = c.ember },
```

And outside `:terminal`, Neovim never asks for them. Its default `guicursor` names a highlight group on exactly one part:

```
n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20,t:block-blinkon500-blinkoff500-TermCursor
```

Only `t:` carries `-TermCursor`. With no group on the normal, insert or replace parts, the terminal draws its own cursor in its own colour. So the theme is correct and invisible at the same time, which is the worst combination for anyone new: nothing looks broken enough to report, and nothing looks right.

## Why this is documentation and not a fix

`guicursor` carries the cursor's shape and its blink, `block`, `ver25`, `hor20`, alongside the group name. A colorscheme that sets it takes a choice that is not its to take: it would overwrite whatever shape the reader picked.

So both routes are documented instead. Install the terminal theme for whatever you run, which every file under `extras/` already sets, and the cursor then matches in the editor and in the shell. Or name the group on the other modes and hand the cursor to Neovim.

## Verified

The `guicursor` line in the docs was run through `vim.opt.guicursor` rather than quoted from memory, and it parses. `helptags` regenerates and `cendre-cursor` lands in `doc/tags`. The vimdoc stays inside `tw=78` except the two lines that were already over it. No em-dashes, `all checks passed`, no drift.