### PR TITLE
chore(groups): drop SnacksBackdrop, which nothing reads

### DIFF
--- a/lua/cendre/groups/integrations.lua
+++ b/lua/cendre/groups/integrations.lua
@@ -28,7 +28,6 @@ function M.get(c)
     SnacksNormal            = { fg = c.fg, bg = c.bg_deep },
     SnacksNormalNC          = { fg = c.fg, bg = c.bg_deep },
     SnacksWinBar            = { fg = c.ember, bold = true },
-    SnacksBackdrop          = { bg = c.bg_deep },
     SnacksPickerTitle       = { fg = c.ember, bold = true },
     SnacksPickerBoxTitle    = { fg = c.ember, bold = true },
     SnacksPickerInputTitle  = { fg = c.ember, bold = true },


### PR DESCRIPTION
One line, and it has never done anything.

## What Snacks actually does

It declares the group, with `default = true` so a theme can override it:

```lua
-- snacks/win.lua:215
Snacks.util.set_hl({ Backdrop = { bg = "#000000" }, ... }, { prefix = "Snacks", default = true })
```

And then never reads it. When a window opens a backdrop, it builds a group name from the colour, sets that group itself, and points `winhighlight` at it:

```lua
-- snacks/win.lua:1074
local group = ("SnacksBackdrop_%s"):format(bg and bg:sub(2) or "T")
vim.api.nvim_set_hl(0, group, { bg = bg })
```

`grep -rn SnacksBackdrop` over the plugin returns exactly one hit, that line. The bare name is declared and never consulted, so overriding it here has had no effect for as long as the line has existed.

## Which also answers a question

The backdrop looks black because it is: Snacks hardcodes `#000000` at `blend = 60`. Over an empty buffer on `bg0` that resolves to roughly `#090705`, which reads as black. That is a plugin option rather than a theme colour, so anyone who wants it lighter sets `backdrop = false`, a lower number, or a table with its own `bg`.

Nothing for the theme to do about it, which is the second reason this line should go: it looks like the theme has a say.

## Verified

`all checks passed`, no generated file changes.

Found while reviewing the mini.nvim contribution in #38.