### PR TITLE
docs: point at the four open discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/surface_request.yml
+++ b/.github/ISSUE_TEMPLATE/surface_request.yml
@@ -2,7 +2,6 @@ name: New surface
 description: Ask for a tool cendre does not theme yet
 title: "Surface: "
 labels: ["enhancement", "extras"]
-assignees: ["Aejkatappaja"]
 body:
   - type: markdown
     attributes:

--- a/README.md
+++ b/README.md
@@ -241,6 +241,19 @@ no readable token leans on bold or italic, and that every committed file under
 `extras/`, `assets/` and `docs/` matches a fresh render of the palette. Exits
 non-zero on failure.
 
+## Discussions
+
+Four threads are open, and none of them is a bug report:
+
+- [Show your setup](https://github.com/Aejkatappaja/cendre/discussions/43), any
+  surface, any depth. The only screenshot here is mine.
+- [Which surface next](https://github.com/Aejkatappaja/cendre/discussions/47), a
+  poll over eight candidates.
+- [Argue with the palette](https://github.com/Aejkatappaja/cendre/discussions/44).
+  The hue is not negotiable, everything chosen around it is.
+- [Install and setup questions](https://github.com/Aejkatappaja/cendre/discussions/45),
+  including the black cursor.
+
 ## Licence
 
 MIT.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1295,7 +1295,7 @@ footer b { color: var(--ember); font-weight: inherit; }
     cend<b>re</b> · dark only, on purpose<br>
     palette generated in oklch, gamut-clipped by chroma reduction, every ratio measured<br>
     <span id="foot"></span><br>
-    <a href="https://github.com/Aejkatappaja/cendre">github.com/Aejkatappaja/cendre</a> · MIT
+    <a href="https://github.com/Aejkatappaja/cendre">github.com/Aejkatappaja/cendre</a> · <a href="https://github.com/Aejkatappaja/cendre/discussions">discussions</a> · MIT
   </p>
   <a class="to-top" href="#" data-top>top<i class="ext up" aria-hidden="true"></i></a>
 </footer>


### PR DESCRIPTION
## What this changes

Four discussion threads were opened and pinned, and nothing linked to them. The
README now names all four at the end, and the site footer carries a link next to
the repo link. Surface requests no longer auto-assign to a single name, since the
whole point of that template is that somebody else can take the port.

## Commit messages

- [x] Every commit follows `type(scope): subject`

`docs: point at the four open discussions` and
`chore(ci): stop auto-assigning surface requests`. Neither is `feat` or `fix`, so
neither produces a changelog entry.

## If this touches colours

It does not. No colour, no hex, no palette key is added, moved or read.

- [x] Nothing generated was edited by hand. The hand-written part of
      `docs/index.html` is the only file under `docs/` touched here, and the one
      changed line is a footer anchor. `favicon.svg` and `og.svg`, the two
      generated files in that folder, are untouched
- [x] Every colour comes from the palette, by not adding one

## If this adds highlight groups

It does not.

## Verified

- [x] `smoke` passes locally, all 18 checks, including the four that read
      `docs/index.html`: same palette as the module, every copyable path exists,
      the printed surface count matches the rows, and every section is a unique
      deep link

```
ok   - the landing page carries the same palette as the module
ok   - every path the landing page tells a reader to copy exists
ok   - the surface count printed on the page matches the rows under it
ok   - every section of the landing page is a unique deep link
----------------------------------------------------
all checks passed
```
