### PR TITLE
feat(palette): ship the derivation, and hold the palette to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,41 @@ Neovim 0.9 or newer, with `termguicolors`.
 Diagnostics, git signs, diff and statusline draw from the semantic family. An
 error never wears the same red as a keyword.
 
+## 27 surfaces, one palette
+
+Neovim is where this starts, not where it stops. Ghostty, kitty, wezterm, foot,
+Alacritty, tmux, bat, delta, lazygit, yazi, eza, fzf, btop, starship, helix, Zed,
+Obsidian, Firefox and the rest, with the path each one installs to:
+[cendretheme.com/#surfaces](https://cendretheme.com/#surfaces).
+
+Nothing under `extras/` or `assets/` is written by hand, nor the favicon and share
+card under `docs/`. All of it is rendered from `lua/cendre/palette.lua`, so a
+colour cannot be right in the editor and stale in a terminal, in this README, or
+on the site:
+
+```sh
+nvim --headless --noplugin -u NONE -c "set rtp+=." -c "luafile scripts/extras.lua" -c q
+```
+
+**Every surface ships at all three depths.** A reader on `soft` wants `soft` in
+their terminal too, so each directory holds `cendre`, `cendre-medium` and
+`cendre-soft`. The unsuffixed name is the depth the plugin defaults to, so the
+editor and everything around it match with no second decision.
+
+Anything that stores a theme name rather than taking it from its filename gets
+that name qualified per depth, or installing two of them collides on one entry in
+Zed, bat, Obsidian and the rest. The test asserts that.
+
+Ghostty, for example:
+
+```
+theme = cendre
+```
+
+The 16 ANSI slots are also exported as `vim.g.terminal_color_*`, so `:terminal`
+matches. Slot 5 is potassium's 404 nm line, derived the same way as the pigments,
+and it exists because ANSI wants six hues while the editor needs five.
+
 ## Three depths, one palette
 
 The pigments are the identity, so they never move. Only the ground under them
@@ -192,39 +227,6 @@ Each hue traced from its spectrum to its hex:
 5. Diagnostics are their own family, separate from the pigments.
 6. Nothing readable under 4.5:1, with three exceptions that are stated rather
    than hidden: `comment` everywhere, and `frost` and `error` on `soft`.
-
-## Everywhere else
-
-Nothing under `extras/` or `assets/` is written by hand, nor the favicon and share
-card under `docs/`. All of it is rendered from `lua/cendre/palette.lua`, so a
-colour cannot be right in the editor and stale in a terminal, in this README, or
-on the site:
-
-```sh
-nvim --headless --noplugin -u NONE -c "set rtp+=." -c "luafile scripts/extras.lua" -c q
-```
-
-**Every surface ships at all three depths.** A reader on `soft` wants `soft` in
-their terminal too, so each directory holds `cendre`, `cendre-medium` and
-`cendre-soft`. The unsuffixed name is the depth the plugin defaults to, so the
-editor and everything around it match with no second decision.
-
-Anything that stores a theme name rather than taking it from its filename gets
-that name qualified per depth, or installing two of them collides on one entry in
-Zed, bat, Obsidian and the rest. The test asserts that.
-
-The full list, with the path each one installs to:
-[cendretheme.com/#surfaces](https://cendretheme.com/#surfaces).
-
-Ghostty, for example:
-
-```
-theme = cendre
-```
-
-The 16 ANSI slots are also exported as `vim.g.terminal_color_*`, so `:terminal`
-matches. Slot 5 is potassium's 404 nm line, derived the same way as the pigments,
-and it exists because ANSI wants six hues while the editor needs five.
 
 ## Test
 

--- a/derive.lua
+++ b/derive.lua
@@ -1,0 +1,100 @@
+-- Cendre's palette, from wavelengths. Run it:
+--
+--   nvim -l derive.lua
+--
+-- No data file and no dependency: the CIE curves have a published analytic fit
+-- and OKLab is two matrix multiplies around a cube root.
+
+-- CIE 1931 2-degree colour matching functions, multi-lobe piecewise-Gaussian
+-- fit. Wyman, Sloan & Shirley, JCGT 2013. Within ~1% of the tabulated values.
+local function g(x, mu, s1, s2)
+  local s = x < mu and s1 or s2
+  return math.exp(-0.5 * ((x - mu) / s) ^ 2)
+end
+
+local function cmf(l)
+  return {
+    1.056 * g(l, 599.8, 37.9, 31.0) + 0.362 * g(l, 442.0, 16.0, 26.7)
+      - 0.065 * g(l, 501.1, 20.4, 26.2),
+    0.821 * g(l, 568.8, 46.9, 40.5) + 0.286 * g(l, 530.9, 16.3, 31.1),
+    1.217 * g(l, 437.0, 11.8, 36.0) + 0.681 * g(l, 459.0, 26.0, 13.8),
+  }
+end
+
+-- Ottosson's OKLab.
+local M1 = { { 0.8189330101, 0.3618667424, -0.1288597137 },
+             { 0.0329845436, 0.9293118715,  0.0361456387 },
+             { 0.0482003018, 0.2643662691,  0.6338517070 } }
+local M2 = { { 0.2104542553,  0.7936177850, -0.0040720468 },
+             { 1.9779984951, -2.4285922050,  0.4505937099 },
+             { 0.0259040371,  0.7827717662, -0.8086757660 } }
+
+local function mul(M, v)
+  local o = {}
+  for i = 1, 3 do
+    o[i] = M[i][1] * v[1] + M[i][2] * v[2] + M[i][3] * v[3]
+  end
+  return o
+end
+
+-- math.atan2 in LuaJIT, math.atan(y, x) from 5.3 on.
+local atan2 = math.atan2 or math.atan
+
+local function oklch(xyz)
+  local lms = mul(M1, xyz)
+  for i = 1, 3 do
+    -- a fractional power of a negative number is NaN, so carry the sign
+    local c = lms[i]
+    lms[i] = c < 0 and -((-c) ^ (1 / 3)) or c ^ (1 / 3)
+  end
+  local lab = mul(M2, lms)
+  local L, a, b = lab[1], lab[2], lab[3]
+  return L, math.sqrt(a * a + b * b), atan2(b, a) * 180 / math.pi % 360
+end
+
+-- An emission line is a delta function, so the integral collapses: XYZ is the
+-- colour matching function evaluated at that wavelength, nothing to sum.
+local function line(nm)
+  return oklch(cmf(nm))
+end
+
+-- Planck's law. Wood coals sit around 1300 K.
+local H, C, K = 6.62607015e-34, 2.99792458e8, 1.380649e-23
+
+local function planck(nm, T)
+  local l = nm * 1e-9
+  return (2 * H * C ^ 2 / l ^ 5) / (math.exp(H * C / (l * K * T)) - 1)
+end
+
+local function blackbody(T)
+  local acc = { 0, 0, 0 }
+  for nm = 360, 830 do
+    local p = planck(nm, T)
+    local c = cmf(nm)
+    for i = 1, 3 do
+      acc[i] = acc[i] + p * c[i]
+    end
+  end
+  return oklch(acc)
+end
+
+local sources = {
+  { "cinder", "CaOH band",    line, 622 },
+  { "ember",  "coals 1300 K", blackbody, 1300 },
+  { "brass",  "sodium D",     line, 589 },
+  { "sap",    "C2 Swan",      line, 563 },
+  { "frost",  "C2 Swan",      line, 474 },
+}
+
+-- Printed for a reader, returned for test/smoke.lua, which replays this file and
+-- holds the shipped pigments to what it computes.
+local derived = {}
+
+for _, s in ipairs(sources) do
+  local name, what, fn, arg = s[1], s[2], s[3], s[4]
+  local _, _, hue = fn(arg)
+  print(string.format("%-8s %-14s %6.1f°", name, what, hue))
+  derived[name] = { source = what, arg = arg, hue = hue }
+end
+
+return derived

--- a/docs/index.html
+++ b/docs/index.html
@@ -1325,7 +1325,7 @@ const DEPTHS = ["hard", "medium", "soft"];
 /** @type {Record<Depth, Ground[]>} */
 const GROUNDS = {
   hard: [
-    { name: "bg_deep", hex: "#0f0c0a", L: 0.156 },
+    { name: "bg_deep", hex: "#0f0c0a", L: 0.157 },
     { name: "bg0", hex: "#171311", L: 0.191 },
     { name: "bg1", hex: "#201b19", L: 0.227 },
     { name: "bg2", hex: "#2a2422", L: 0.266 },
@@ -1334,12 +1334,12 @@ const GROUNDS = {
     { name: "bg5", hex: "#5a504c", L: 0.440 },
   ],
   medium: [
-    { name: "bg_deep", hex: "#141110", L: 0.182 },
+    { name: "bg_deep", hex: "#141110", L: 0.181 },
     { name: "bg0", hex: "#1d1917", L: 0.217 },
     { name: "bg1", hex: "#26211f", L: 0.253 },
     { name: "bg2", hex: "#312a28", L: 0.292 },
-    { name: "bg3", hex: "#3d3633", L: 0.338 },
-    { name: "bg4", hex: "#4e4541", L: 0.397 },
+    { name: "bg3", hex: "#3d3633", L: 0.339 },
+    { name: "bg4", hex: "#4e4541", L: 0.398 },
     { name: "bg5", hex: "#625753", L: 0.466 },
   ],
   soft: [
@@ -1347,9 +1347,9 @@ const GROUNDS = {
     { name: "bg0", hex: "#231f1d", L: 0.243 },
     { name: "bg1", hex: "#2d2725", L: 0.279 },
     { name: "bg2", hex: "#37312e", L: 0.318 },
-    { name: "bg3", hex: "#443c39", L: 0.364 },
-    { name: "bg4", hex: "#554c48", L: 0.423 },
-    { name: "bg5", hex: "#695e5a", L: 0.492 },
+    { name: "bg3", hex: "#443c39", L: 0.363 },
+    { name: "bg4", hex: "#554c48", L: 0.424 },
+    { name: "bg5", hex: "#695e5a", L: 0.491 },
   ],
 };
 
@@ -1363,9 +1363,9 @@ const DEPTH_NOTE = {
 /** @type {Swatch[]} */
 const INK = [
   { name: "fg", hex: "#e6d5c2", hue: 70.5, L: 0.882, C: 0.032, hard: 12.89, medium: 12.19, soft: 11.42 },
-  { name: "fg_dim", hex: "#a09384", hue: 71.3, L: 0.670, C: 0.027, hard: 6.15, medium: 5.82, soft: 5.45 },
-  { name: "comment", hex: "#73665b", hue: 62.0, L: 0.520, C: 0.024, hard: 3.32, medium: 3.14, soft: 2.94 },
-  { name: "gutter", hex: "#4e4641", hue: 56.4, L: 0.400, C: 0.014, hard: 2.00, medium: 1.89, soft: 1.77 },
+  { name: "fg_dim", hex: "#a09384", hue: 71.3, L: 0.670, C: 0.026, hard: 6.15, medium: 5.82, soft: 5.45 },
+  { name: "comment", hex: "#73665b", hue: 62.5, L: 0.519, C: 0.024, hard: 3.32, medium: 3.14, soft: 2.94 },
+  { name: "gutter", hex: "#4e4641", hue: 54.1, L: 0.401, C: 0.014, hard: 2.00, medium: 1.89, soft: 1.77 },
 ];
 
 /**
@@ -1408,11 +1408,11 @@ const WHY = {
 
 /** @type {Swatch[]} */
 const SEMANTIC = [
-  { name: "error", hex: "#d25780", hue: 2.0, L: 0.639, C: 0.160, hard: 4.76, medium: 4.50, soft: 4.21 },
-  { name: "warning", hex: "#f4a21c", hue: 71.7, L: 0.760, C: 0.160, hard: 8.82, medium: 8.33, soft: 7.81 },
-  { name: "ok · git add", hex: "#43b16a", hue: 152.1, L: 0.681, C: 0.145, hard: 6.80, medium: 6.43, soft: 6.02 },
-  { name: "hint", hex: "#20c9cb", hue: 196.2, L: 0.759, C: 0.125, hard: 9.03, medium: 8.54, soft: 8.00 },
-  { name: "info · git change", hex: "#58bdff", hue: 240.4, L: 0.766, C: 0.133, hard: 8.91, medium: 8.42, soft: 7.89 },
+  { name: "error", hex: "#d25780", hue: 2.0, L: 0.625, C: 0.160, hard: 4.76, medium: 4.50, soft: 4.21 },
+  { name: "warning", hex: "#f4a21c", hue: 71.7, L: 0.775, C: 0.160, hard: 8.82, medium: 8.33, soft: 7.81 },
+  { name: "ok · git add", hex: "#43b16a", hue: 152.1, L: 0.680, C: 0.145, hard: 6.80, medium: 6.43, soft: 6.02 },
+  { name: "hint", hex: "#20c9cb", hue: 196.2, L: 0.760, C: 0.125, hard: 9.03, medium: 8.54, soft: 8.00 },
+  { name: "info · git change", hex: "#58bdff", hue: 240.4, L: 0.766, C: 0.134, hard: 8.91, medium: 8.42, soft: 7.89 },
 ];
 
 /** @type {Record<Depth, Tints>} */
@@ -1423,7 +1423,7 @@ const TINTS = {
 };
 
 /** ANSI wants six hues where the editor needs five, so this one is terminal only. */
-const POTASSIUM = { hex: "#9480ba", L: 0.640, C: 0.088, hue: 299.8, ratio: 5.32 };
+const POTASSIUM = { hex: "#9480ba", L: 0.640, C: 0.088, hue: 299.7, ratio: 5.32 };
 
 /** The two bright slots with no editor role: the same hues, lightness raised 0.06. */
 const POTASSIUM_BRIGHT = "#a692cd";

--- a/docs/index.html
+++ b/docs/index.html
@@ -1066,10 +1066,12 @@ footer b { color: var(--ember); font-weight: inherit; }
       <p>What we chose is lightness and chroma, because a spectral line is far outside sRGB and has
         to be brought into gamut anyway. Hue survived that trip intact; the last column is what
         actually shipped.</p>
-      <p>The computation is in the repository, 93 lines with no data file and no dependency, because
-        those curves have a published analytic fit and OKLab is two matrix multiplies around a cube
-        root. <code>nvim -l derive.lua</code> prints the derived column below, and the test suite
-        holds this table to it.</p>
+      <p>The computation is in the repository, a hundred lines with no data file and no dependency,
+        because those curves have a published analytic fit and OKLab is two matrix multiplies around
+        a cube root. <code>nvim -l derive.lua</code> prints the derived column below, and the test
+        suite holds this table to it. The fit is the approximation in the chain: its authors publish
+        it as within about one percent of the tabulated curves, which is worth up to a degree of hue
+        here.</p>
     </div>
     <div class="scroll">
       <table>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1066,6 +1066,10 @@ footer b { color: var(--ember); font-weight: inherit; }
       <p>What we chose is lightness and chroma, because a spectral line is far outside sRGB and has
         to be brought into gamut anyway. Hue survived that trip intact; the last column is what
         actually shipped.</p>
+      <p>The computation is in the repository, 93 lines with no data file and no dependency, because
+        those curves have a published analytic fit and OKLab is two matrix multiplies around a cube
+        root. <code>nvim -l derive.lua</code> prints the derived column below, and the test suite
+        holds this table to it.</p>
     </div>
     <div class="scroll">
       <table>
@@ -1376,9 +1380,9 @@ const PIGMENTS = [
     hard: 8.13, medium: 7.69, soft: 7.20, src: "blackbody · 1300 K" },
   { name: "brass", hex: "#fcba81", hue: 61.4, derived: 61.4, L: 0.838, C: 0.106,
     hard: 10.97, medium: 10.37, soft: 9.72, src: "sodium D · 589 nm" },
-  { name: "sap", hex: "#99af6b", hue: 123.4, derived: 123.2, L: 0.721, C: 0.095,
+  { name: "sap", hex: "#99af6b", hue: 123.4, derived: 124.1, L: 0.721, C: 0.095,
     hard: 7.65, medium: 7.23, soft: 6.77, src: "C₂ Swan · 563 nm" },
-  { name: "frost", hex: "#4e89a2", hue: 227.4, derived: 226.6, L: 0.600, C: 0.072,
+  { name: "frost", hex: "#4e89a2", hue: 227.4, derived: 226.0, L: 0.600, C: 0.072,
     hard: 4.77, medium: 4.51, soft: 4.22, src: "C₂ Swan · 474 nm" },
 ];
 

--- a/lua/cendre/extras/terminals.lua
+++ b/lua/cendre/extras/terminals.lua
@@ -346,10 +346,9 @@ function M.tokyo_night_tmux(bg)
     -- read as a background, under the active window block and the clock, so it has
     -- to lift off "background" above by enough to mark a state: bg4 is 0.105 of
     -- lightness clear of bg2, where bg3 would have been 0.046 and would whisper.
-    --
-    -- The plugin also reads this same slot as the ink of its session block, over
-    -- the accent, where a fill this light only reaches 4.4:1. Both roles cannot be
-    -- served by one value; the state marker is the one that carries meaning.
+    -- The plugin also reads this slot as the ink of its session block, over the
+    -- accent, where a fill this light only reaches 4.4:1. One value cannot serve
+    -- both; the state marker is the one that carries meaning.
     { "bblack", c.bg4 },
 
     { "bblue", c.terminal_bright_blue },

--- a/lua/cendre/groups/editor.lua
+++ b/lua/cendre/groups/editor.lua
@@ -53,7 +53,6 @@ function M.get(c)
     WinSeparator = { fg = c.bg3, bg = c.bg0 },
     VertSplit    = { fg = c.bg3, bg = c.bg0 },
 
-    -- messages
     ModeMsg      = { fg = c.ember, bold = true },
     MoreMsg      = { fg = c.info },
     Question     = { fg = c.info },
@@ -73,7 +72,6 @@ function M.get(c)
     qfLineNr     = { fg = c.gutter },
     qfFileName   = { fg = c.frost },
 
-    -- diff
     DiffAdd      = { bg = c.add },
     DiffDelete   = { bg = c.del },
     DiffChange   = { bg = c.mod },
@@ -87,7 +85,6 @@ function M.get(c)
     diffLine     = { fg = c.comment },
     diffIndexLine = { fg = c.comment },
 
-    -- spell
     SpellBad     = { undercurl = true, sp = c.error },
     SpellCap     = { undercurl = true, sp = c.warn },
     SpellLocal   = { undercurl = true, sp = c.info },

--- a/lua/cendre/init.lua
+++ b/lua/cendre/init.lua
@@ -17,7 +17,6 @@ M.config = {
 --- Register :CendreBackground. Called from load() rather than setup(), because a
 --- bare `colorscheme cendre` with no configuration is a supported way to install
 --- this, and it should not be the way that silently loses the command.
---- @return nil
 local function register_command()
   vim.api.nvim_create_user_command("CendreBackground", function(o)
     local palette = require("cendre.palette")

--- a/lua/cendre/palette.lua
+++ b/lua/cendre/palette.lua
@@ -34,7 +34,7 @@ end
 -- cursorline has to read as one material at different distances.
 M.grounds = {
   hard = {
-    bg_deep = "#0f0c0a", -- L 0.156 · floats, sidebars
+    bg_deep = "#0f0c0a", -- L 0.157 · floats, sidebars
     bg0     = "#171311", -- L 0.191 · editor
     bg1     = "#201b19", -- L 0.227 · cursorline
     bg2     = "#2a2422", -- L 0.266 · statusline
@@ -43,12 +43,12 @@ M.grounds = {
     bg5     = "#5a504c", -- L 0.440 · highest layer
   },
   medium = {
-    bg_deep = "#141110", -- L 0.182
+    bg_deep = "#141110", -- L 0.181
     bg0     = "#1d1917", -- L 0.217
     bg1     = "#26211f", -- L 0.253
     bg2     = "#312a28", -- L 0.292
-    bg3     = "#3d3633", -- L 0.338
-    bg4     = "#4e4541", -- L 0.397
+    bg3     = "#3d3633", -- L 0.339
+    bg4     = "#4e4541", -- L 0.398
     bg5     = "#625753", -- L 0.466
   },
   soft = {
@@ -56,9 +56,9 @@ M.grounds = {
     bg0     = "#231f1d", -- L 0.243
     bg1     = "#2d2725", -- L 0.279
     bg2     = "#37312e", -- L 0.318
-    bg3     = "#443c39", -- L 0.364
-    bg4     = "#554c48", -- L 0.423
-    bg5     = "#695e5a", -- L 0.492
+    bg3     = "#443c39", -- L 0.363
+    bg4     = "#554c48", -- L 0.424
+    bg5     = "#695e5a", -- L 0.491
   },
 }
 
@@ -71,8 +71,8 @@ M.grounds = {
 M.ink = {
   fg      = "#e6d5c2", -- L 0.882 · 12.89:1 on hard
   fg_dim  = "#a09384", -- L 0.670 ·  6.15:1 · operators, delimiters
-  comment = "#73665b", -- L 0.520 ·  3.32:1 · quiet on purpose
-  gutter  = "#4e4641", -- L 0.400 ·  2.00:1 · line numbers, inlay
+  comment = "#73665b", -- L 0.519 ·  3.32:1 · quiet on purpose
+  gutter  = "#4e4641", -- L 0.401 ·  2.00:1 · line numbers, inlay
 }
 
 -- The five pigments, in order of lightness, which is also order of distance
@@ -94,7 +94,7 @@ M.semantic = {
   warn  = "#f4a21c", --  71.7° · C 0.160
   ok    = "#43b16a", -- 152.1° · C 0.145
   hint  = "#20c9cb", -- 196.2° · C 0.125
-  info  = "#58bdff", -- 240.4° · C 0.133
+  info  = "#58bdff", -- 240.4° · C 0.134
 }
 
 -- Tinted grounds for diff and visual, per depth, so a selection lifts off the
@@ -108,7 +108,7 @@ M.tints = {
 -- Derived like the pigments, and not one of them: it fills ANSI slot 5 and never
 -- touches a token, so it stays out of M.pigments.
 M.spectral = {
-  potassium        = "#9480ba", -- 299.8° · L 0.640 · potassium 404 nm · ANSI slot 5
+  potassium        = "#9480ba", -- 299.7° · L 0.640 · potassium 404 nm · ANSI slot 5
   potassium_bright = "#a692cd", -- same hue, L +0.06
 }
 

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -967,6 +967,30 @@ check("every pigment carries the hue its source emits", function()
   end
 end)
 
+check("the derivation table on the page is what derive.lua prints", function()
+  local page = io.open("docs/index.html", "r")
+  assert(page, "docs/index.html is missing")
+  local html = page:read("*a")
+  page:close()
+
+  local spoken = print
+  _G.print = function() end
+  local ok, derived = pcall(assert(loadfile("derive.lua")))
+  _G.print = spoken
+  assert(ok and type(derived) == "table", "derive.lua did not return what it computed")
+
+  -- The page tells a reader that nvim -l derive.lua prints this column, and it
+  -- carries its own copy to render without Lua, so the two have to agree to the
+  -- decimal it publishes.
+  for _, name in ipairs(PIGMENTS) do
+    local published = html:match('name:%s*"' .. name .. '".-derived:%s*([%d%.]+)')
+    assert(published, "docs/index.html publishes no derived hue for " .. name)
+    assert(math.abs(tonumber(published) - derived[name].hue) < 0.05,
+      ("%s: the page publishes %s° derived, derive.lua computes %.1f°"):format(
+        name, published, derived[name].hue))
+  end
+end)
+
 check("the gaps the palette claims between its warm three are the gaps it ships", function()
   local src = io.open("lua/cendre/palette.lua", "r")
   local body = src:read("*a")

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -42,6 +42,41 @@ local function ratio(a, b)
   return (hi + 0.05) / (lo + 0.05)
 end
 
+-- Same matrices as derive.lua, which comes at OKLCH from the other end, wavelengths.
+local SRGB_XYZ = { { 0.4123907993, 0.3575843394, 0.1804807884 },
+                   { 0.2126390059, 0.7151686788, 0.0721923154 },
+                   { 0.0193308187, 0.1191947798, 0.9505321522 } }
+local XYZ_LMS = { { 0.8189330101, 0.3618667424, -0.1288597137 },
+                  { 0.0329845436, 0.9293118715,  0.0361456387 },
+                  { 0.0482003018, 0.2643662691,  0.6338517070 } }
+local LMS_LAB = { { 0.2104542553,  0.7936177850, -0.0040720468 },
+                  { 1.9779984951, -2.4285922050,  0.4505937099 },
+                  { 0.0259040371,  0.7827717662, -0.8086757660 } }
+
+local function mul(M, v)
+  local o = {}
+  for i = 1, 3 do
+    o[i] = M[i][1] * v[1] + M[i][2] * v[2] + M[i][3] * v[3]
+  end
+  return o
+end
+
+local atan2 = math.atan2 or math.atan
+
+--- @return number lightness, number chroma, number hue in degrees
+local function oklch(hex)
+  local r, g, b = hex:match("^#(%x%x)(%x%x)(%x%x)$")
+  assert(r, "not a hex colour: " .. tostring(hex))
+  local lms = mul(XYZ_LMS, mul(SRGB_XYZ, { lin(tonumber(r, 16)), lin(tonumber(g, 16)), lin(tonumber(b, 16)) }))
+  for i = 1, 3 do
+    local c = lms[i]
+    lms[i] = c < 0 and -((-c) ^ (1 / 3)) or c ^ (1 / 3)
+  end
+  local lab = mul(LMS_LAB, lms)
+  local L, a, bb = lab[1], lab[2], lab[3]
+  return L, math.sqrt(a * a + bb * bb), atan2(bb, a) * 180 / math.pi % 360
+end
+
 -- load() pushes every highlight through nvim_set_hl, which throws on a nil or
 -- malformed colour. A clean load is therefore the core regression guard: any
 -- group referencing a missing palette key blows up right here.
@@ -857,6 +892,106 @@ check("lualine theme follows the active background", function()
   local theme = require("lualine.themes.cendre")
   assert(theme.normal.c.bg == require("cendre.palette").grounds.soft.bg2,
     "lualine still on the wrong ground")
+end)
+
+-- The palette writes a hue, a lightness and a source in the margin beside every
+-- pigment. Those three claims are the reason to prefer this theme over one whose
+-- colours were picked, so none of them gets to be a comment nobody rechecks.
+local PIGMENTS = { "brass", "ember", "sap", "cinder", "frost" }
+
+--- The margin of M.pigments, parsed: hue, lightness and the source line as written.
+local function margin()
+  local src = io.open("lua/cendre/palette.lua", "r")
+  assert(src, "lua/cendre/palette.lua is missing")
+  local body = src:read("*a")
+  src:close()
+
+  local block = body:match("M%.pigments%s*=%s*{(.-)\n}")
+  assert(block, "M.pigments is no longer a single table literal")
+
+  local out = {}
+  for name, hex, hue, l, source in block:gmatch('(%w+)%s*=%s*"(#%x+)",%s*%-%-%s*([%d%.]+)°%s*·%s*L%s*([%d%.]+)%s*·%s*(.-)%s*·') do
+    out[name] = { hex = hex, hue = tonumber(hue), l = tonumber(l), source = source }
+  end
+  return out
+end
+
+check("the palette's margin matches the colours it ships", function()
+  local noted = margin()
+  local c = require("cendre.palette").pigments
+
+  for _, name in ipairs(PIGMENTS) do
+    local note = noted[name]
+    assert(note, "no annotated line for " .. name .. " in M.pigments")
+    assert(note.hex == c[name],
+      ("%s: the margin sits beside %s but the table holds %s"):format(name, note.hex, c[name]))
+
+    local L, _, hue = oklch(note.hex)
+    assert(math.abs(hue - note.hue) < 0.05,
+      ("%s: margin says %.1f°, %s is %.1f°"):format(name, note.hue, note.hex, hue))
+    assert(math.abs(L - note.l) < 0.0005,
+      ("%s: margin says L %.3f, %s is L %.3f"):format(name, note.l, note.hex, L))
+  end
+end)
+
+check("every pigment carries the hue its source emits", function()
+  -- derive.lua is a script that prints for a reader; here only its return matters
+  local chunk = loadfile("derive.lua")
+  assert(chunk, "derive.lua is missing: the palette's provenance is unverifiable")
+
+  local spoken = print
+  _G.print = function() end
+  local ok, derived = pcall(chunk)
+  _G.print = spoken
+  assert(ok, "derive.lua failed to run: " .. tostring(derived))
+  assert(type(derived) == "table", "derive.lua no longer returns what it computed")
+
+  local noted = margin()
+
+  -- The CMF fit derive.lua uses is published as within ~1% of the tabulated
+  -- curves, and bringing a spectral line into sRGB rotates it a little more, so
+  -- this is not an equality. Frost is the widest, at 1.4°.
+  local TOLERANCE = 2.0
+
+  for _, name in ipairs(PIGMENTS) do
+    local from_source = derived[name]
+    assert(from_source, "derive.lua computes no hue for " .. name)
+
+    local _, _, hue = oklch(noted[name].hex)
+    assert(math.abs(hue - from_source.hue) <= TOLERANCE,
+      ("%s: %s is %.1f°, its source gives %.1f°"):format(name, noted[name].hex, hue, from_source.hue))
+
+    -- and the margin has to name the number derive.lua was actually handed
+    assert(noted[name].source:match(tostring(math.floor(from_source.arg))),
+      ("%s: the margin reads \"%s\", derive.lua used %s"):format(name, noted[name].source, from_source.arg))
+  end
+end)
+
+check("the gaps the palette claims between its warm three are the gaps it ships", function()
+  local src = io.open("lua/cendre/palette.lua", "r")
+  local body = src:read("*a")
+  src:close()
+
+  local first, second = body:match("land%s+([%d%.]+)°%s+and%s+([%d%.]+)°%s+apart")
+  assert(first, "the header no longer states the spacing of cinder, ember and brass")
+
+  -- The header restates the figures in the margin, to one decimal, so it is held
+  -- to those and not to the full-precision hues: 61.4 less 43.8 is the 17.6 it
+  -- claims, where the hexes themselves are 17.69 apart. The margin is tied to the
+  -- hexes by the check above, so the chain still reaches the shipped colour.
+  local noted = margin()
+
+  -- both sides are written to one decimal, so anything under that is float noise
+  local function same(a, b)
+    return math.abs(a - b) < 1e-9
+  end
+
+  assert(same(noted.ember.hue - noted.cinder.hue, tonumber(first)),
+    ("cinder to ember is %.1f° in the margin, the header claims %s°"):format(
+      noted.ember.hue - noted.cinder.hue, first))
+  assert(same(noted.brass.hue - noted.ember.hue, tonumber(second)),
+    ("ember to brass is %.1f° in the margin, the header claims %s°"):format(
+      noted.brass.hue - noted.ember.hue, second))
 end)
 
 print(("-"):rep(52))

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -967,6 +967,74 @@ check("every pigment carries the hue its source emits", function()
   end
 end)
 
+-- L, C and hue are published in two places that render without Lua, the module's
+-- own margin and the page's data tables, to the decimal each one prints. Both are
+-- recomputed from the hex they sit beside: half a unit in the last place is the
+-- tolerance, so a figure that rounds the wrong way is a failure like any other.
+local function annotated(body, pattern)
+  local found = {}
+  for line in body:gmatch("[^\n]+") do
+    local hex = line:match('"(#%x%x%x%x%x%x)"')
+    local note = hex and line:match(pattern)
+    if note then
+      found[#found + 1] = { hex = hex, note = note, line = line }
+    end
+  end
+  return found
+end
+
+-- The decimal point is required: "C2 Swan 563 nm" sits in the same margin and
+-- reads as a chroma of 2 to anything looser.
+local function claims(note)
+  return {
+    { "L", tonumber(note:match("L:?%s*(%d%.%d+)")), 1, 0.0005 },
+    { "C", tonumber(note:match("C:?%s*(%d%.%d+)")), 2, 0.0005 },
+    { "hue", tonumber(note:match("hue:%s*(%d+%.%d)") or note:match("(%d+%.%d)°")), 3, 0.05 },
+  }
+end
+
+check("every lightness and hue the module's margin prints is the hex beside it", function()
+  local src = io.open("lua/cendre/palette.lua", "r")
+  assert(src, "lua/cendre/palette.lua is missing")
+  local body = src:read("*a")
+  src:close()
+
+  local rows = annotated(body, "%-%-%s*(.*)$")
+  assert(#rows >= 30, "only " .. #rows .. " annotated colours found, the margin cannot have shrunk that far")
+
+  for _, row in ipairs(rows) do
+    local measured = { oklch(row.hex) }
+    for _, c in ipairs(claims(row.note)) do
+      local field, want, index, tolerance = c[1], c[2], c[3], c[4]
+      if want then
+        assert(math.abs(measured[index] - want) < tolerance,
+          ("%s: margin says %s %s, %s is %.4f"):format(row.hex, field, want, row.hex, measured[index]))
+      end
+    end
+  end
+end)
+
+check("every lightness and hue the page publishes is the hex beside it", function()
+  local page = io.open("docs/index.html", "r")
+  assert(page, "docs/index.html is missing")
+  local body = page:read("*a")
+  page:close()
+
+  local rows = annotated(body, 'hex: "#%x+",%s*(.*)$')
+  assert(#rows >= 30, "only " .. #rows .. " annotated colours found on the page")
+
+  for _, row in ipairs(rows) do
+    local measured = { oklch(row.hex) }
+    for _, c in ipairs(claims(row.note)) do
+      local field, want, index, tolerance = c[1], c[2], c[3], c[4]
+      if want then
+        assert(math.abs(measured[index] - want) < tolerance,
+          ("%s: the page publishes %s %s, the hex is %.4f"):format(row.hex, field, want, measured[index]))
+      end
+    end
+  end
+end)
+
 check("the derivation table on the page is what derive.lua prints", function()
   local page = io.open("docs/index.html", "r")
   assert(page, "docs/index.html is missing")


### PR DESCRIPTION
The README opens on Planck's law, the CIE 1931 colour matching functions and OKLCH. `M.pigments` writes a hue, a lightness and a source in the margin beside every colour. None of it could be rechecked: the computation lived outside the repository, so the strongest claim this theme makes was the one nothing verified.

### derive.lua

A hundred lines, no data file and no dependency. The CMF have a published analytic fit (Wyman, Sloan & Shirley, JCGT 2013), Planck's law is four constants, OKLab is two matrix multiplies around a cube root. An emission line is a delta function, so the integral collapses to evaluating the curves at that wavelength.

```
$ nvim -l derive.lua
cinder   CaOH band        25.5°
ember    coals 1300 K     43.8°
brass    sodium D         61.4°
sap      C2 Swan         124.1°
frost    C2 Swan         226.0°
```

### What the tests now hold

Each claim is checked against what it derives from, never against a number typed twice.

| check | tolerance |
| --- | --- |
| margin hue and L, recomputed from the hex beside them | 0.05° / 0.0005 L |
| shipped hue against what the source emits | 2° |
| margin names the number derive.lua was handed (`sodium D 589 nm`) | exact |
| header spacing of the warm three against its own margin | one decimal |

The 2° is the one loose bound and it is deliberate. The fit is published as within ~1% of the tabulated curves, and gamut mapping a spectral line into sRGB rotates it further. Measured: ember and brass land exactly, cinder 0.4° out, sap 0.7°, frost 1.4°. Anything past 2° is a colour that stopped matching its source, not arithmetic noise.

One thing this surfaced: the module header says the warm three sit 17.9° and 17.6° apart, but the hexes are 17.69° apart, because the header subtracts the two rounded figures in the margin. The check holds the header to the margin, and the margin to the hex, so the chain still reaches the shipped colour without pretending to a precision the prose never had.

### Also here

- the README leads with the 27 surfaces instead of burying them at section eight under the generation process
- three comments removed that restated the code they sat on, and one `@return nil` on a local returning nothing

`POST.md` stays out, it is blog copy rather than repository content.
