### PR TITLE
fix(italic): keep the attribute where it is the meaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,18 @@ lualine picks it up with `options.theme = "cendre"`, or leave `"auto"`.
 | ----------------- | ---------- | -------------------------------------------------------- |
 | `background`      | `"hard"`   | ground depth: `hard`, `medium` or `soft`                  |
 | `transparent`     | `false`    | strips Normal, floats and the statusline; plugin windows follow |
-| `italic`          | `false`    | italics across the theme                                  |
-| `italic_comments` | `true`     | keeps comments italic even when `italic = false`           |
+| `italic`          | `false`    | italics on virtual text: inlay hints, ghost text, git blame |
+| `italic_comments` | `true`     | italics on comments, independently of `italic`             |
 | `on_colors`       | noop       | `function(colors)` mutates the palette before highlights  |
 | `on_highlights`   | noop       | `function(highlights, colors)` gets the last word         |
 
 The background is painted by default. The ash bed is a colour the theme derived,
 so it may as well be on screen.
+
+The two italic switches are independent, not one overriding the other, so
+`italic = false` on its own leaves comments italic. Set both to `false` for no
+italics. `Italic` and `@markup.italic` are outside both, because italic is their
+entire definition: strip it and `*emphasis*` renders as body text.
 
 With `transparent = true`, plugin windows go through too, without being listed one
 by one: which-key, the Snacks picker, Noice and fzf-lua link their windows to

--- a/doc/cendre.txt
+++ b/doc/cendre.txt
@@ -106,13 +106,24 @@ Accepts a table. Every key is optional; pass only what you want to change.
 
     italic              boolean     default false
 
-        Italics across the theme. Every role keeps a real gap from the
-        others, so italics carry no information here.
+        Italics on virtual text: inlay hints, ghost text, git blame, Noice.
+        No syntax role is italic at any setting, because every role already
+        keeps a real gap from the others, so italics carry no information
+        there.
 
     italic_comments     boolean     default true
 
-        Keeps comments italic even when `italic` is false. Set both to false
-        for no italics anywhere.
+        Italics on comments, and on everything the editor treats as one:
+        `SpecialComment`, `@lsp.type.comment`, `LspCodeLens` and
+        `@markup.quote` follow it too, so a comment does not change shape
+        the moment a language server attaches.
+
+        The two switches are independent. `italic = false` on its own leaves
+        comments italic; set both to false for no italics.
+
+        `Italic` and `@markup.italic` answer to neither. Italic is their
+        whole definition, and they carry no foreground, so stripping it
+        would render `*emphasis*` as body text.
 
     on_colors           function    default noop
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -427,7 +427,8 @@ code { font-family: var(--mono); font-size: 0.92em; color: var(--ink2); }
 .cm { color: var(--ink3); font-style: italic; }
 .err { color: var(--error); }
 .wrn { color: var(--warn); }
-.virt { color: var(--gutter); font-style: italic; }
+/* No DiagnosticVirtualText group leans italic, at any setting. */
+.virt { color: var(--gutter); }
 .squig { border-bottom: 2px dotted var(--error); }
 
 /* ---- specimen tabs ---- */

--- a/lua/cendre/init.lua
+++ b/lua/cendre/init.lua
@@ -14,6 +14,22 @@ M.config = {
   on_highlights = function(highlights, colors) end,
 }
 
+-- Which switch each italic group answers to. Anything absent follows `italic`.
+--
+-- The comment family is wider than the three names a reader thinks of, because an
+-- LSP attaching swaps Comment for @lsp.type.comment, and a comment that changes
+-- shape when the server connects reads as a bug.
+local ITALIC = {}
+for _, name in ipairs({ "Italic", "@markup.italic" }) do
+  ITALIC[name] = "markup"
+end
+for _, name in ipairs({
+  "Comment", "SpecialComment", "@comment", "@comment.documentation",
+  "@lsp.type.comment", "LspCodeLens", "@markup.quote",
+}) do
+  ITALIC[name] = "comment"
+end
+
 --- Register :CendreBackground. Called from load() rather than setup(), because a
 --- bare `colorscheme cendre` with no configuration is a supported way to install
 --- this, and it should not be the way that silently loses the command.
@@ -79,21 +95,15 @@ function M.load()
     highlights.FloatBorder = { fg = c.bg3, bg = "NONE" }
   end
 
-  if not M.config.italic then
-    for _, hl in pairs(highlights) do
-      hl.italic = false
-    end
-    if M.config.italic_comments then
-      for _, name in ipairs({ "Comment", "@comment", "@comment.documentation" }) do
-        if highlights[name] then
-          highlights[name].italic = true
-        end
-      end
-    end
-  elseif not M.config.italic_comments then
-    for _, name in ipairs({ "Comment", "@comment", "@comment.documentation" }) do
-      if highlights[name] then
-        highlights[name].italic = false
+  -- Markup answers to neither switch: italic is the whole definition there, and a
+  -- stripped one leaves an empty group, so *emphasis* would render as body text.
+  for name, hl in pairs(highlights) do
+    if hl.italic then
+      local family = ITALIC[name]
+      if family == "comment" then
+        hl.italic = M.config.italic_comments
+      elseif family ~= "markup" then
+        hl.italic = M.config.italic
       end
     end
   end

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -194,22 +194,6 @@ check("transparent = false keeps Normal bg", function()
   assert(vim.api.nvim_get_hl(0, { name = "Normal" }).bg == 0x171311, "Normal bg wrong")
 end)
 
-check("italic = false, italic_comments = true", function()
-  reload()
-  require("cendre").setup({ italic = false, italic_comments = true })
-  require("cendre").load()
-  assert(vim.api.nvim_get_hl(0, { name = "Comment" }).italic, "Comment lost its italic")
-  assert(not vim.api.nvim_get_hl(0, { name = "@variable.parameter" }).italic,
-    "parameter still italic")
-end)
-
-check("italic_comments = false kills every italic", function()
-  reload()
-  require("cendre").setup({ italic = false, italic_comments = false })
-  require("cendre").load()
-  assert(not vim.api.nvim_get_hl(0, { name = "Comment" }).italic, "Comment still italic")
-end)
-
 check("on_colors override", function()
   reload()
   require("cendre").setup({ on_colors = function(colors) colors.bg0 = "#000000" end })
@@ -456,6 +440,41 @@ check("nothing readable depends on bold or italic", function()
     local hl = vim.api.nvim_get_hl(0, { name = group })
     assert(not hl.bold, group .. " leans on bold")
     assert(not hl.italic, group .. " leans on italic")
+  end
+end)
+
+-- One group per family, so the four rows the README prints are a contract.
+check("the italic switches do what the options table says", function()
+  local MATRIX = {
+    -- italic, italic_comments, comment, virtual text, markup
+    { false, true, true, false, true },
+    { false, false, false, false, true },
+    { true, true, true, true, true },
+    { true, false, false, true, true },
+  }
+
+  for _, row in ipairs(MATRIX) do
+    local italic, italic_comments, comment, virtual, markup = row[1], row[2], row[3], row[4], row[5]
+    reload()
+    require("cendre").setup({ background = "hard", italic = italic, italic_comments = italic_comments })
+    require("cendre").load()
+
+    local function is_italic(group)
+      return vim.api.nvim_get_hl(0, { name = group }).italic == true
+    end
+    local function want(group, expected, why)
+      assert(is_italic(group) == expected,
+        ("italic=%s italic_comments=%s: %s is %s, %s"):format(
+          italic, italic_comments, group, tostring(is_italic(group)), why))
+    end
+
+    want("Comment", comment, "comments follow italic_comments")
+    want("@lsp.type.comment", comment, "an LSP attaching must not reshape a comment")
+    want("SpecialComment", comment, "a special comment is still a comment")
+    want("LspInlayHint", virtual, "virtual text follows italic")
+    want("BlinkCmpGhostText", virtual, "ghost text is virtual text")
+    want("Italic", markup, "this group carries no fg: stripped, it means nothing")
+    want("@markup.italic", markup, "*emphasis* has to stay emphasised")
   end
 end)
 
@@ -894,9 +913,8 @@ check("lualine theme follows the active background", function()
     "lualine still on the wrong ground")
 end)
 
--- The palette writes a hue, a lightness and a source in the margin beside every
--- pigment. Those three claims are the reason to prefer this theme over one whose
--- colours were picked, so none of them gets to be a comment nobody rechecks.
+-- The margin beside every pigment claims a hue, a lightness and a source. None of
+-- the three gets to be a comment nobody rechecks.
 local PIGMENTS = { "brass", "ember", "sap", "cinder", "frost" }
 
 --- The margin of M.pigments, parsed: hue, lightness and the source line as written.
@@ -967,10 +985,8 @@ check("every pigment carries the hue its source emits", function()
   end
 end)
 
--- L, C and hue are published in two places that render without Lua, the module's
--- own margin and the page's data tables, to the decimal each one prints. Both are
--- recomputed from the hex they sit beside: half a unit in the last place is the
--- tolerance, so a figure that rounds the wrong way is a failure like any other.
+-- Both copies, the module's margin and the page's data tables, get recomputed from
+-- the hex they sit beside, to half a unit in the last place each one prints.
 local function annotated(body, pattern)
   local found = {}
   for line in body:gmatch("[^\n]+") do
@@ -1047,9 +1063,7 @@ check("the derivation table on the page is what derive.lua prints", function()
   _G.print = spoken
   assert(ok and type(derived) == "table", "derive.lua did not return what it computed")
 
-  -- The page tells a reader that nvim -l derive.lua prints this column, and it
-  -- carries its own copy to render without Lua, so the two have to agree to the
-  -- decimal it publishes.
+  -- The page tells a reader that nvim -l derive.lua prints this column, so it has to.
   for _, name in ipairs(PIGMENTS) do
     local published = html:match('name:%s*"' .. name .. '".-derived:%s*([%d%.]+)')
     assert(published, "docs/index.html publishes no derived hue for " .. name)
@@ -1067,10 +1081,9 @@ check("the gaps the palette claims between its warm three are the gaps it ships"
   local first, second = body:match("land%s+([%d%.]+)°%s+and%s+([%d%.]+)°%s+apart")
   assert(first, "the header no longer states the spacing of cinder, ember and brass")
 
-  -- The header restates the figures in the margin, to one decimal, so it is held
-  -- to those and not to the full-precision hues: 61.4 less 43.8 is the 17.6 it
-  -- claims, where the hexes themselves are 17.69 apart. The margin is tied to the
-  -- hexes by the check above, so the chain still reaches the shipped colour.
+  -- Held to the margin rather than to the full-precision hues, because that is what
+  -- it restates: 61.4 less 43.8 is the 17.6 claimed, the hexes are 17.69 apart. The
+  -- check above ties the margin to the hexes, so the chain still reaches the colour.
   local noted = margin()
 
   -- both sides are written to one decimal, so anything under that is float noise


### PR DESCRIPTION
Refs #52. The report was about wording, and the wording was wrong, but two defects were sitting under it.

### `*emphasis*` rendered as body text

`Italic` and `@markup.italic` are defined with nothing but the attribute: no foreground, no background. `italic = false` is the default and the old code stripped italic from every group that carried it, so those two became empty highlight groups. In a markdown file, `*important*` looked exactly like the text around it. In a default install.

They now answer to neither switch. Italic is what those groups mean, and a theme option sets appearance, it does not delete information. Same reason nobody expects a `bold` option to unbold `**bold**`.

### Comments were half a family

Fourteen groups carry italic. The restore list named three: `Comment`, `@comment`, `@comment.documentation`. So on the default config `SpecialComment`, `@lsp.type.comment`, `LspCodeLens` and `@markup.quote` came out upright, and a comment changed shape the moment a language server attached and `@lsp.type.comment` took over. All seven follow `italic_comments` now.

### Three families, one rule each

| family | groups | switch |
| --- | --- | --- |
| markup | `Italic`, `@markup.italic` | neither, always italic |
| comments | the seven above | `italic_comments`, default `true` |
| virtual text | `LspInlayHint`, `BlinkCmpGhostText`, `GitSignsCurrentLineBlame`, `NoiceVirtualText` | `italic`, default `false` |

Which makes the documented contract this:

| `italic` | `italic_comments` | comments | virtual text | `@markup.italic` |
| --- | --- | --- | --- | --- |
| `false` | `true` (default) | italic | upright | italic |
| `false` | `false` | upright | upright | italic |
| `true` | `true` | italic | italic | italic |
| `true` | `false` | upright | italic | italic |

Asserted in `smoke.lua` against one group per family, including `@lsp.type.comment` for the LSP-attach flip and the two markup groups that carry no foreground. It replaces two checks that asserted `Comment` alone, one of which was named for killing every italic, which is no longer what it should do.

### Docs

`italic` was documented as "italics across the theme". No syntax role is italic at any setting, so that promise was never kept, and it is what makes the option read as a master switch. Both rows now name their scope, in the README and in `:help cendre-options`, with the independence spelled out under the table. The landing page had the same untruth in CSS: `.virt` rendered diagnostic virtual text italic, where no `DiagnosticVirtualText` group leans italic.

### Visible change

Everyone gets markdown emphasis back. On the default config, four comment groups move from upright to italic. `italic_comments = false` puts all seven upright. Behaviour of `italic` itself is unchanged.

The option naming is not addressed here: `italic` still reads like a master switch even with honest docs. That is a rename with a deprecation path, and it does not belong in a bug fix.