### PR TITLE
fix(groups): give float surfaces their own ground, in blink and noice

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ With `transparent = true`, plugin windows go through too, without being listed o
 by one: which-key, the Snacks picker, Noice and fzf-lua link their windows to
 `NormalFloat`, so stripping that strips all of them, including plugins released
 after this README. The completion menu is the exception and stays painted, since a
-transparent popup over code is not readable.
+transparent popup over code is not readable. That covers `Pmenu` and blink.cmp's own
+windows, which read neither `Pmenu` nor `NormalFloat`.
 
 ```lua
 require("cendre").setup({

--- a/doc/cendre.txt
+++ b/doc/cendre.txt
@@ -102,7 +102,11 @@ Accepts a table. Every key is optional; pass only what you want to change.
         `NormalFloat` and their edges to `FloatBorder`, so stripping those two
         strips every one of them, including plugins released after this file.
         The completion menu is the exception and stays painted: a transparent
-        popup over code is not readable.
+        popup over code is not readable. blink.cmp points its windows at
+        `BlinkCmpMenu`, `BlinkCmpDoc` and `BlinkCmpSignatureHelp` rather than at
+        `Pmenu` or `NormalFloat`, so those three and their borders are painted
+        too. blink draws no border of its own by default, `border` in its own
+        options turns one on.
 
     italic              boolean     default false
 

--- a/lua/cendre/groups/integrations.lua
+++ b/lua/cendre/groups/integrations.lua
@@ -99,8 +99,12 @@ function M.get(c)
     WhichKeyValue     = { fg = c.comment },
     WhichKeyIcon      = { fg = c.brass },
 
-    -- noice
+    -- noice. The three borders default to DiagnosticSign groups, so without these
+    -- an ember title sits inside an info-blue frame.
     NoiceCmdlinePopupTitle = { fg = c.ember, bold = true },
+    NoiceCmdlinePopupBorder = { fg = c.ember },
+    NoiceCmdlinePopupBorderSearch = { fg = c.brass },
+    NoiceConfirmBorder    = { fg = c.ember },
     NoiceCmdlineIcon      = { fg = c.ember },
     NoiceCmdlineIconSearch = { fg = c.brass },
     NoiceMini             = { fg = c.fg_dim, bg = c.bg1 },

--- a/lua/cendre/groups/integrations.lua
+++ b/lua/cendre/groups/integrations.lua
@@ -52,7 +52,15 @@ function M.get(c)
     SnacksNotifierDebug     = { fg = c.comment },
     SnacksNotifierTrace     = { fg = c.comment },
 
-    -- blink.cmp
+    -- blink.cmp. winhighlight points its windows here, not at Pmenu or NormalFloat,
+    -- so undefined means a popup with no ground. Painted under transparent, like Pmenu.
+    BlinkCmpMenu                = { fg = c.fg, bg = c.bg_deep },
+    BlinkCmpMenuBorder          = { fg = c.bg3, bg = c.bg_deep },
+    BlinkCmpDoc                 = { fg = c.fg, bg = c.bg_deep },
+    BlinkCmpDocBorder           = { fg = c.bg3, bg = c.bg_deep },
+    BlinkCmpSignatureHelp       = { fg = c.fg, bg = c.bg_deep },
+    BlinkCmpSignatureHelpBorder = { fg = c.bg3, bg = c.bg_deep },
+
     BlinkCmpMenuSelection  = { bg = c.bg3, bold = true },
     BlinkCmpScrollBarThumb = { bg = c.bg4 },
     BlinkCmpScrollBarGutter = { bg = c.bg1 },

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -154,6 +154,10 @@ check("no group repeats a float surface, so plugin windows can inherit it", func
   local allowed = {
     SnacksNormal = true, SnacksNormalNC = true, NeoTreeWinSeparator = true,
     Pmenu = true,
+    -- blink's windows read none of the float surfaces, so they have to pin their own
+    BlinkCmpMenu = true, BlinkCmpMenuBorder = true,
+    BlinkCmpDoc = true, BlinkCmpDocBorder = true,
+    BlinkCmpSignatureHelp = true, BlinkCmpSignatureHelpBorder = true,
   }
   for name, hl in pairs(built) do
     if not surfaces[name] and not allowed[name] then
@@ -178,8 +182,9 @@ check("transparent = true leaves no window surface painted", function()
 
   -- Anything a plugin points a window at ends in one of these. A ground colour
   -- surviving here means the reader asked to see their terminal and got a panel.
+  -- The completion menu is the documented exception, borders included.
   for name, hl in pairs(vim.api.nvim_get_hl(0, {})) do
-    if hl.bg and grounds[hl.bg] and
+    if hl.bg and grounds[hl.bg] and not name:match("^BlinkCmp") and
       (name:match("Normal$") or name:match("NormalNC$") or name:match("Float$")
        or name:match("Border$") or name:match("Popup$") or name:match("Cmdline$")) then
       error(name .. " still paints " .. grounds[hl.bg] .. " under transparent = true")


### PR DESCRIPTION
Two gaps found while chasing a report of completion popups printing straight over the buffer.

### blink.cmp's windows had no ground

blink points its windows at `BlinkCmpMenu`, `BlinkCmpDoc` and `BlinkCmpSignatureHelp` through `winhighlight`, so they read neither `Pmenu` nor `NormalFloat`. None of the three was defined here, which left the popup with no background of its own.

The documented transparency exception was implemented on `Pmenu` alone, so it covered built-in completion and nvim-cmp and missed blink, which is LazyVim's default engine. The three surfaces and their borders now carry `bg_deep` and stay painted under `transparent = true`, for the reason `Pmenu` does. The borders take the same ground rather than a bare stroke, since an opaque popup ringed by one transparent cell reads worse than either.

They pin a float colour deliberately, so they join `Pmenu` in the two checks that otherwise forbid it.

### noice's borders were not themed

The cmdline icons and the popup title were, the borders around them were not, so all three fell through to Noice's defaults:

| group | fell through to | rendered |
| --- | --- | --- |
| `NoiceCmdlinePopupBorder` | `DiagnosticSignInfo` | `#58bdff` |
| `NoiceCmdlinePopupBorderSearch` | `DiagnosticSignWarn` | `#f4a21c` |
| `NoiceConfirmBorder` | `DiagnosticSignInfo` | `#58bdff` |

Typing `:` gave an ember title inside an info-blue frame. Each border now takes the colour of the icon it frames, ember and brass. They set no background, so transparency is unaffected.

`NoicePopup` and `NoicePopupBorder` are deliberately left alone: Noice links them to `NormalFloat` and `FloatBorder` already, which is where they belong, and pinning them here would hold a colour `transparent = true` could no longer strip.

### Not a theme problem, for the record

Two things that look like this bug and are not fixable from a colorscheme. `vim.o.winborder`, new in 0.11, is what creates a border character at all; empty means no border exists to colour. And Noice's `hover` view ships `border.style = "none"`, which overrides that global for LSP hover and signature help. Both are user-config, and the help file now says so next to the blink group names.