### PR TITLE
docs: name the plugins that carry their own groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Ghostty, for example:
 theme = cendre
 ```
 
+Inside the editor, these get groups of their own rather than whatever their
+defaults land on: gitsigns, blink.cmp, Snacks, fzf-lua, which-key, Noice,
+neo-tree, nvim-tree, flash, trouble, lazy.nvim, mason, nvim-dap and dap-ui,
+neotest, mini.indentscope, mini.hipatterns, hlchunk, grug-far, diffview,
+illuminate, treesitter-context and rainbow-delimiters.
+
 The 16 ANSI slots are also exported as `vim.g.terminal_color_*`, so `:terminal`
 matches. Slot 5 is potassium's 404 nm line, derived the same way as the pigments,
 and it exists because ANSI wants six hues while the editor needs five.

--- a/doc/cendre.txt
+++ b/doc/cendre.txt
@@ -295,6 +295,12 @@ plugin defaults to, and `-medium` and `-soft` sit beside it. Anything that
 stores a theme name rather than taking it from its filename carries that name
 qualified per depth, or installing two of them collides on one entry.
 
+Inside the editor, these carry groups of their own rather than whatever their
+defaults land on: gitsigns, blink.cmp, Snacks, fzf-lua, which-key, Noice,
+neo-tree, nvim-tree, flash, trouble, lazy.nvim, mason, nvim-dap and dap-ui,
+neotest, mini.indentscope, mini.hipatterns, hlchunk, grug-far, diffview,
+illuminate, treesitter-context and rainbow-delimiters.
+
 The 16 ANSI slots are exported as `vim.g.terminal_color_0` through
 `vim.g.terminal_color_15`, so |:terminal| matches. Slot 5 is potassium's
 404 nm line, derived the same way as the pigments; it exists because ANSI

--- a/docs/index.html
+++ b/docs/index.html
@@ -172,7 +172,7 @@ code { font-family: var(--mono); font-size: 0.92em; color: var(--ink2); }
 .note { font-family: var(--mono); font-size: 0.75rem; color: var(--ink3); line-height: 1.6; }
 
 /* One sentence per line above the fold width, ordinary prose below it. */
-.lines { max-width: 78ch; }
+.lines { max-width: none; }
 @media (min-width: 760px) { .lines span { display: block; } }
 
 .gap-lg { margin-bottom: 1.5rem; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1260,6 +1260,11 @@ footer b { color: var(--ember); font-weight: inherit; }
         <code>-medium</code> or <code>-soft</code> sits beside it.</span>
         <span>Click a command to copy it.</span></p>
     </div>
+    <p class="note gap-sm">Inside the editor, these carry groups of their own rather than whatever
+      their defaults land on: gitsigns, blink.cmp, Snacks, fzf-lua, which-key, Noice, neo-tree,
+      nvim-tree, flash, trouble, lazy.nvim, mason, nvim-dap and dap-ui, neotest, mini.indentscope,
+      mini.hipatterns, hlchunk, grug-far, diffview, illuminate, treesitter-context and
+      rainbow-delimiters.</p>
     <div class="scroll">
       <table class="surfaces">
         <caption><span id="surface-count">27</span> surfaces · every file generated, never hand-edited</caption>


### PR DESCRIPTION
`integrations.lua` defines 226 groups across twenty-odd plugins, and nothing said so. The README, the help file and the site all described coverage as surfaces beyond the editor, which left the work inside it invisible: a reader comparing this to a theme that only paints syntax had no way to know their lazy, dap and diffview were handled.

Named rather than counted, in all three places. A count would go stale on the next group added; this list moves only when a plugin does. Every one of the 22 names was checked against `integrations.lua` before being written down.

`mini` is listed as `mini.indentscope` and `mini.hipatterns`, which is what is actually covered. Claiming mini.nvim would oversell it, and the rest of it is being discussed in #38.

### Also

`.lines` capped its measure at 78ch inside a wrap that already caps at 1180px, so the longer sentences in that block wrapped onto a second line, which is the one thing a one-sentence-per-line block exists to prevent. The note and the table beside it were already running full width, so the section had two measures for no reason.
