### PR TITLE
feat(config): rename italic to italic_virtual_text

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ lazy.nvim:
   config = function()
     require("cendre").setup({
       background = "hard", -- "hard" | "medium" | "soft"
-      italic = false,
+      italic_virtual_text = false,
     })
   end,
 },
@@ -122,8 +122,8 @@ lualine picks it up with `options.theme = "cendre"`, or leave `"auto"`.
 | ----------------- | ---------- | -------------------------------------------------------- |
 | `background`      | `"hard"`   | ground depth: `hard`, `medium` or `soft`                  |
 | `transparent`     | `false`    | strips Normal, floats and the statusline; plugin windows follow |
-| `italic`          | `false`    | italics on virtual text: inlay hints, ghost text, git blame |
-| `italic_comments` | `true`     | italics on comments, independently of `italic`             |
+| `italic_virtual_text` | `false` | italics on inlay hints, ghost text, git blame, the dashboard footer |
+| `italic_comments` | `true`     | italics on comments, independently of the above             |
 | `on_colors`       | noop       | `function(colors)` mutates the palette before highlights  |
 | `on_highlights`   | noop       | `function(highlights, colors)` gets the last word         |
 
@@ -131,9 +131,11 @@ The background is painted by default. The ash bed is a colour the theme derived,
 so it may as well be on screen.
 
 The two italic switches are independent, not one overriding the other, so
-`italic = false` on its own leaves comments italic. Set both to `false` for no
-italics. `Italic` and `@markup.italic` are outside both, because italic is their
-entire definition: strip it and `*emphasis*` renders as body text.
+`italic_virtual_text = false` on its own leaves comments italic. Set both to
+`false` for no italics. `italic` is the old name for `italic_virtual_text`, kept
+as an alias that warns, and removed in 2.0. `Italic` and `@markup.italic` are
+outside both, because italic is their entire definition: strip it and
+`*emphasis*` renders as body text.
 
 With `transparent = true`, plugin windows go through too, without being listed one
 by one: which-key, the Snacks picker, Noice and fzf-lua link their windows to

--- a/doc/cendre.txt
+++ b/doc/cendre.txt
@@ -58,7 +58,7 @@ With lazy.nvim: >lua
       config = function()
         require("cendre").setup({
           background = "hard",
-          italic = false,
+          italic_virtual_text = false,
         })
       end,
     }
@@ -108,12 +108,17 @@ Accepts a table. Every key is optional; pass only what you want to change.
         too. blink draws no border of its own by default, `border` in its own
         options turns one on.
 
-    italic              boolean     default false
+    italic_virtual_text boolean     default false
 
-        Italics on virtual text: inlay hints, ghost text, git blame, Noice.
-        No syntax role is italic at any setting, because every role already
-        keeps a real gap from the others, so italics carry no information
-        there.
+        Italics on the text the editor adds around yours: `LspInlayHint`,
+        `BlinkCmpGhostText`, `GitSignsCurrentLineBlame`, `NoiceVirtualText`
+        and `SnacksDashboardFooter`. No syntax role is italic at any setting,
+        because every role already keeps a real gap from the others, so
+        italics carry no information there.
+
+        This option was called `italic`. That name read as a switch for the
+        whole theme and never was one, so it is now an alias that warns
+        through |vim.deprecate()|, and it goes away in 2.0.
 
     italic_comments     boolean     default true
 
@@ -122,8 +127,8 @@ Accepts a table. Every key is optional; pass only what you want to change.
         `@markup.quote` follow it too, so a comment does not change shape
         the moment a language server attaches.
 
-        The two switches are independent. `italic = false` on its own leaves
-        comments italic; set both to false for no italics.
+        The two switches are independent. `italic_virtual_text = false` on
+        its own leaves comments italic; set both to false for no italics.
 
         `Italic` and `@markup.italic` answer to neither. Italic is their
         whole definition, and they carry no foreground, so stripping it

--- a/docs/index.html
+++ b/docs/index.html
@@ -1806,7 +1806,7 @@ return M`;
   config = function()
     require("cendre").setup({
       background = "${depth}", -- "hard" | "medium" | "soft"
-      italic = false,
+      italic_virtual_text = false,
     })
   end,
 },

--- a/lua/cendre/init.lua
+++ b/lua/cendre/init.lua
@@ -6,15 +6,18 @@ M.config = {
   background = "hard",
   -- The ash bed is a colour the theme derived, so it may as well be on screen.
   transparent = false,
-  -- Every role keeps a real gap from the others, so italics carry no
-  -- information here. Off by default.
-  italic = false,
+  -- Italics on the text the editor adds around yours: inlay hints, ghost text,
+  -- git blame, Noice virtual text, the dashboard footer. No syntax role is italic
+  -- at any setting, since every role already keeps a real gap from the others.
+  italic_virtual_text = false,
   italic_comments = true,
   on_colors = function(colors) end,
   on_highlights = function(highlights, colors) end,
 }
 
--- Which switch each italic group answers to. Anything absent follows `italic`.
+-- Which switch each italic group answers to. Every family is listed, so a group
+-- added later is classified on purpose rather than inheriting a switch whose name
+-- does not describe it.
 --
 -- The comment family is wider than the three names a reader thinks of, because an
 -- LSP attaching swaps Comment for @lsp.type.comment, and a comment that changes
@@ -28,6 +31,12 @@ for _, name in ipairs({
   "@lsp.type.comment", "LspCodeLens", "@markup.quote",
 }) do
   ITALIC[name] = "comment"
+end
+for _, name in ipairs({
+  "LspInlayHint", "BlinkCmpGhostText", "GitSignsCurrentLineBlame",
+  "NoiceVirtualText", "SnacksDashboardFooter",
+}) do
+  ITALIC[name] = "virtual"
 end
 
 --- Register :CendreBackground. Called from load() rather than setup(), because a
@@ -54,7 +63,19 @@ local function register_command()
 end
 
 function M.setup(opts)
-  M.config = vim.tbl_deep_extend("force", M.config, opts or {})
+  opts = vim.tbl_extend("force", {}, opts or {})
+
+  -- `italic` never reached anything but virtual text, so it read as a master
+  -- switch it never was. Removed in 2.0.
+  if opts.italic ~= nil then
+    vim.deprecate("cendre italic", "italic_virtual_text", "2.0.0", "cendre")
+    if opts.italic_virtual_text == nil then
+      opts.italic_virtual_text = opts.italic
+    end
+    opts.italic = nil
+  end
+
+  M.config = vim.tbl_deep_extend("force", M.config, opts)
   register_command()
 end
 
@@ -102,8 +123,8 @@ function M.load()
       local family = ITALIC[name]
       if family == "comment" then
         hl.italic = M.config.italic_comments
-      elseif family ~= "markup" then
-        hl.italic = M.config.italic
+      elseif family == "virtual" then
+        hl.italic = M.config.italic_virtual_text
       end
     end
   end

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -376,7 +376,7 @@ end
 
 check("the role map holds: every pigment lands where the page says", function()
   reload()
-  require("cendre").setup({ background = "hard", italic = false })
+  require("cendre").setup({ background = "hard", italic_virtual_text = false })
   require("cendre").load()
   local c = require("cendre").colors
   local want = {
@@ -437,7 +437,7 @@ end)
 
 check("nothing readable depends on bold or italic", function()
   reload()
-  require("cendre").setup({ background = "hard", italic = false })
+  require("cendre").setup({ background = "hard", italic_virtual_text = false })
   require("cendre").load()
   for _, group in ipairs({
     "@keyword", "@function", "@type", "@string", "@number", "@property", "@variable",
@@ -451,7 +451,7 @@ end)
 -- One group per family, so the four rows the README prints are a contract.
 check("the italic switches do what the options table says", function()
   local MATRIX = {
-    -- italic, italic_comments, comment, virtual text, markup
+    -- italic_virtual_text, italic_comments, comment, virtual text, markup
     { false, true, true, false, true },
     { false, false, false, false, true },
     { true, true, true, true, true },
@@ -459,9 +459,13 @@ check("the italic switches do what the options table says", function()
   }
 
   for _, row in ipairs(MATRIX) do
-    local italic, italic_comments, comment, virtual, markup = row[1], row[2], row[3], row[4], row[5]
+    local virtual_text, italic_comments, comment, virtual, markup = row[1], row[2], row[3], row[4], row[5]
     reload()
-    require("cendre").setup({ background = "hard", italic = italic, italic_comments = italic_comments })
+    require("cendre").setup({
+      background = "hard",
+      italic_virtual_text = virtual_text,
+      italic_comments = italic_comments,
+    })
     require("cendre").load()
 
     local function is_italic(group)
@@ -469,8 +473,8 @@ check("the italic switches do what the options table says", function()
     end
     local function want(group, expected, why)
       assert(is_italic(group) == expected,
-        ("italic=%s italic_comments=%s: %s is %s, %s"):format(
-          italic, italic_comments, group, tostring(is_italic(group)), why))
+        ("italic_virtual_text=%s italic_comments=%s: %s is %s, %s"):format(
+          virtual_text, italic_comments, group, tostring(is_italic(group)), why))
     end
 
     want("Comment", comment, "comments follow italic_comments")
@@ -481,6 +485,25 @@ check("the italic switches do what the options table says", function()
     want("Italic", markup, "this group carries no fg: stripped, it means nothing")
     want("@markup.italic", markup, "*emphasis* has to stay emphasised")
   end
+end)
+
+check("the old italic option still works, and says it is going away", function()
+  reload()
+  local told
+  local real = vim.deprecate
+  vim.deprecate = function(name, alternative, version)
+    told = { name = name, alternative = alternative, version = version }
+  end
+  require("cendre").setup({ background = "hard", italic = true })
+  vim.deprecate = real
+  require("cendre").load()
+
+  assert(told, "setting italic said nothing about the rename")
+  assert(told.alternative == "italic_virtual_text",
+    "pointed at " .. tostring(told.alternative) .. " instead of italic_virtual_text")
+  assert(told.version == "2.0.0", "a deprecation without a removal version is not a promise")
+  assert(vim.api.nvim_get_hl(0, { name = "LspInlayHint" }).italic == true,
+    "italic = true no longer reaches virtual text")
 end)
 
 check("every surface ships at all three depths", function()


### PR DESCRIPTION
Refs #55.

`italic` read as a switch for the whole theme and never was one. It reached four groups of virtual text plus the dashboard footer, and no syntax role is italic at any setting, by design. #52 is what that costs: a reader sets `italic = false`, expects nothing italic, and gets italic comments.

```lua
require("cendre").setup({
  italic_comments = true,      -- default, unchanged
  italic_virtual_text = false, -- default, was `italic`
})
```

`italic` stays as an alias that maps onto the new name and warns:

```
cendre italic is deprecated, use italic_virtual_text instead.
Feature will be removed in cendre 2.0.0
```

Nobody's config breaks. Setting both lets the explicit one win. On the version: removing an option is breaking, so the removal is what produces 2.0.0, however many minors ship before it.

### Virtual text is a listed family now

It used to be the fallback for anything that was neither comment nor markup. With the option named for virtual text that fallback would have lied about the next italic group that is neither, so the five are listed: `LspInlayHint`, `BlinkCmpGhostText`, `GitSignsCurrentLineBlame`, `NoiceVirtualText`, `SnacksDashboardFooter`. An unclassified group now keeps the italic it was authored with rather than quietly answering a switch that does not describe it.

The footer is the loose one: it is not virtual text, it is decorative chrome. It sits in this family because it is text the editor adds around yours, which is what the option covers, and the help file says so by naming all five.

### Tests

The matrix check moves to the new name. A second one holds the alias by stubbing `vim.deprecate`: that setting `italic` maps to virtual text, that it points at `italic_virtual_text`, and that it names `2.0.0`, since a deprecation without a removal version is not a promise.

The last box on #55, removing `italic`, stays open for 2.0.