### PR TITLE
fix(groups): one ground for a selected row, wherever the list floats

### DIFF
--- a/lua/cendre/groups/integrations.lua
+++ b/lua/cendre/groups/integrations.lua
@@ -61,7 +61,7 @@ function M.get(c)
     BlinkCmpSignatureHelp       = { fg = c.fg, bg = c.bg_deep },
     BlinkCmpSignatureHelpBorder = { fg = c.bg3, bg = c.bg_deep },
 
-    BlinkCmpMenuSelection  = { bg = c.bg3, bold = true },
+    BlinkCmpMenuSelection  = { bg = c.bg2, bold = true },
     BlinkCmpScrollBarThumb = { bg = c.bg4 },
     BlinkCmpScrollBarGutter = { bg = c.bg1 },
     BlinkCmpLabel          = { fg = c.fg },


### PR DESCRIPTION
Raised by @pkazmier in #38: why does a picker cursor line and a completion selection use different backgrounds when they do the same job?

They shouldn't. Before this:

| group | ground |
| --- | --- |
| `SnacksPickerCursorLine` | `bg2` |
| `FzfLuaCursorLine` | `bg2` |
| `BlinkCmpMenuSelection` | `bg3` |

blink was the outlier, and since the native popup menu moved onto the float layer all three windows sit on `bg_deep`, so there was nothing left justifying two values for marking the row the cursor is on in a floating list.

`bg2` rather than `bg3`, because `bg3` was the odd one out and every ink that lands on that row reads better on the darker ground:

| ink | on `bg2` | on `bg3` |
| --- | --- | --- |
| `fg` | 10.67:1 | 9.16:1 |
| `ember` | 6.73:1 | 5.78:1 |
| `frost` | 3.95:1 | 3.39:1 |

`CursorLine` and `NeoTreeCursorLine` stay on `bg1`. A buffer and a persistent sidebar are not floating lists and their ground is not `bg_deep`, so the same reasoning does not reach them.

`PmenuSel` is not here. It is currently an ember fill, which is the other half of the same inconsistency, and it lands with the mini.nvim work in #38 where it was found.