### PR TITLE
fix: give a float an edge that reads, and let transparency keep it

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ so it lands within a degree of the bare flame itself. Shown at `hard`, the defau
 | `bg0`     | `#171311` | 0.191 | editor             |
 | `bg1`     | `#201b19` | 0.227 | cursorline         |
 | `bg2`     | `#2a2422` | 0.266 | statusline         |
-| `bg3`     | `#362f2c` | 0.312 | borders, splits    |
+| `bg3`     | `#362f2c` | 0.312 | splits             |
 | `bg4`     | `#463e3a` | 0.371 | hover              |
-| `bg5`     | `#5a504c` | 0.440 | highest layer      |
+| `bg5`     | `#5a504c` | 0.440 | float edges        |
 
 Ink, shared by every depth. Ratios against `bg0` at `hard`:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1763,9 +1763,9 @@ M.colors = {
   bg0     = "${g.bg0}", -- editor
   bg1     = "${g.bg1}", -- cursorline
   bg2     = "${g.bg2}", -- statusline
-  bg3     = "${g.bg3}", -- borders, splits
+  bg3     = "${g.bg3}", -- splits
   bg4     = "${g.bg4}", -- hover
-  bg5     = "${g.bg5}", -- highest layer
+  bg5     = "${g.bg5}", -- float edges
 
   fg      = "${ink.fg}", -- ${INK[0][depth].toFixed(2)}:1
   fg_dim  = "${ink.fg_dim}", -- operators, delimiters

--- a/lua/cendre/groups/editor.lua
+++ b/lua/cendre/groups/editor.lua
@@ -5,7 +5,7 @@ function M.get(c)
     Normal       = { fg = c.fg, bg = c.bg0 },
     NormalNC     = { fg = c.fg, bg = c.bg0 },
     NormalFloat  = { fg = c.fg, bg = c.bg_deep },
-    FloatBorder  = { fg = c.bg3, bg = c.bg_deep },
+    FloatBorder  = { fg = c.bg5, bg = c.bg_deep },
     FloatTitle   = { fg = c.ember, bold = true },
     FloatFooter  = { fg = c.comment, bg = c.bg_deep },
 

--- a/lua/cendre/groups/integrations.lua
+++ b/lua/cendre/groups/integrations.lua
@@ -55,11 +55,11 @@ function M.get(c)
     -- blink.cmp. winhighlight points its windows here, not at Pmenu or NormalFloat,
     -- so undefined means a popup with no ground. Painted under transparent, like Pmenu.
     BlinkCmpMenu                = { fg = c.fg, bg = c.bg_deep },
-    BlinkCmpMenuBorder          = { fg = c.bg3, bg = c.bg_deep },
+    BlinkCmpMenuBorder          = { fg = c.bg5, bg = c.bg_deep },
     BlinkCmpDoc                 = { fg = c.fg, bg = c.bg_deep },
-    BlinkCmpDocBorder           = { fg = c.bg3, bg = c.bg_deep },
+    BlinkCmpDocBorder           = { fg = c.bg5, bg = c.bg_deep },
     BlinkCmpSignatureHelp       = { fg = c.fg, bg = c.bg_deep },
-    BlinkCmpSignatureHelpBorder = { fg = c.bg3, bg = c.bg_deep },
+    BlinkCmpSignatureHelpBorder = { fg = c.bg5, bg = c.bg_deep },
 
     BlinkCmpMenuSelection  = { bg = c.bg2, bold = true },
     BlinkCmpScrollBarThumb = { bg = c.bg4 },
@@ -199,7 +199,7 @@ function M.get(c)
     DapUIStoppedThread  = { fg = c.warn },
     DapUISource         = { fg = c.frost },
     DapUILineNumber     = { fg = c.gutter },
-    DapUIFloatBorder    = { fg = c.bg3 },
+    DapUIFloatBorder    = { fg = c.bg5 },
     DapUIWatchesEmpty   = { fg = c.comment },
     DapUIWatchesValue   = { fg = c.ok },
     DapUIWatchesError   = { fg = c.error },

--- a/lua/cendre/init.lua
+++ b/lua/cendre/init.lua
@@ -106,14 +106,15 @@ function M.load()
       "NeoTreeNormal", "NeoTreeNormalNC", "NeoTreeWinSeparator", "NeoTreeEndOfBuffer",
       "NvimTreeNormal", "SnacksNormal", "SnacksNormalNC", "TroubleNormal",
       "DiffviewNormal", "TreesitterContext",
+      -- stripped rather than dropped: a transparent float with no border has no
+      -- edge, so the ground goes and the stroke stays as the groups declare it.
+      "FloatBorder",
     }
     for _, name in ipairs(strip) do
       if highlights[name] then
         highlights[name].bg = "NONE"
       end
     end
-    -- keep the border stroke: a transparent float with no border has no edge
-    highlights.FloatBorder = { fg = c.bg3, bg = "NONE" }
   end
 
   -- Markup answers to neither switch: italic is the whole definition there, and a

--- a/lua/cendre/palette.lua
+++ b/lua/cendre/palette.lua
@@ -38,9 +38,9 @@ M.grounds = {
     bg0     = "#171311", -- L 0.191 · editor
     bg1     = "#201b19", -- L 0.227 · cursorline
     bg2     = "#2a2422", -- L 0.266 · statusline
-    bg3     = "#362f2c", -- L 0.312 · borders, splits
+    bg3     = "#362f2c", -- L 0.312 · splits
     bg4     = "#463e3a", -- L 0.371 · hover
-    bg5     = "#5a504c", -- L 0.440 · highest layer
+    bg5     = "#5a504c", -- L 0.440 · float edges
   },
   medium = {
     bg_deep = "#141110", -- L 0.181

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -113,6 +113,25 @@ check("transparent = true strips Normal bg", function()
   assert(vim.api.nvim_get_hl(0, { name = "Normal" }).bg == nil, "Normal bg not stripped")
 end)
 
+check("every float edge is the same stroke", function()
+  reload()
+  local c = require("cendre.palette").get("hard")
+  local built = {}
+  for _, mod in ipairs({ "editor", "syntax", "treesitter", "lsp", "integrations" }) do
+    for name, hl in pairs(require("cendre.groups." .. mod).get(c)) do built[name] = hl end
+  end
+
+  -- A border on the float ground is the generic float edge and takes one colour.
+  -- Noice's accent borders set no background, so they stay out by construction.
+  local want = built.FloatBorder.fg
+  for name, hl in pairs(built) do
+    if name:match("Border$") and hl.bg == c.bg_deep then
+      assert(hl.fg == want,
+        ("%s strokes %s where FloatBorder strokes %s"):format(name, tostring(hl.fg), tostring(want)))
+    end
+  end
+end)
+
 check("transparent = true keeps the float border stroke", function()
   reload()
   require("cendre").setup({ transparent = true })

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -120,6 +120,13 @@ check("transparent = true keeps the float border stroke", function()
   local hl = vim.api.nvim_get_hl(0, { name = "FloatBorder" })
   assert(hl.bg == nil, "FloatBorder bg not stripped")
   assert(hl.fg ~= nil, "FloatBorder lost its stroke")
+
+  -- And it is the same stroke, not a second one: stripping the ground is the only
+  -- thing transparency is allowed to do to an edge.
+  local c = require("cendre.palette").get("hard")
+  local want = require("cendre.groups.editor").get(c).FloatBorder.fg
+  assert(("#%06x"):format(hl.fg) == want,
+    ("transparent strokes #%06x where the theme strokes %s"):format(hl.fg, want))
 end)
 
 check("no group repeats a float surface, so plugin windows can inherit it", function()


### PR DESCRIPTION
Floats did not separate from the buffer behind them, and under `transparent = true` they could not be fixed at all.

## The edge

`bg_deep` sits 0.033 of OKLCH lightness *below* `bg0`, so a float never lifted off the buffer, it sank a third of a step into it. That left the border carrying the separation, and `bg3` is only 0.121 above the text it has to separate from.

`bg4` was the obvious next step and the wrong one. It is the theme's barely-there value, worn by `NonText`, `SpecialKey` and the indent guides, which is the wrong class for the one cue that has to register. `bg5` was unused in core and the palette has called it the highest layer from the start.

```
      bg3   0.121 of lightness above the buffer
      bg4   0.180
      bg5   0.249
```

Every border on the float ground moves together: `FloatBorder`, the three `BlinkCmp*Border` and `DapUIFloatBorder`. `WinSeparator` and `VertSplit` stay on `bg3`, and Noice's cmdline keeps the accent, since an accented dialog is its own role rather than a generic float edge.

## The bug underneath

The transparent branch did not strip `FloatBorder`, it re-declared it:

```lua
highlights.FloatBorder = { fg = c.bg3, bg = "NONE" }
```

Hardcoded past whatever the groups say. So transparent users have been getting the weakest stroke in the theme, out of reach of any fix, and the first attempt at the change above silently did nothing. `FloatBorder` now goes through the same `strip` list as everything else, which already did what the comment above that line described.

The guard for it only asserted the stroke was non-nil, never that it was the right one. It compares against `editor.lua` now.

## Verified

Both depths of the problem, at `transparent = true` where the stroke is the only cue left:

- a two-pane Snacks picker reads as frames rather than boxes, and the stroke stays below the dim path prefixes inside the list, so the frame does not outrank the content
- a small hover float with full-brightness code touching its edge holds, where `bg3` did not

Discussed in #38 with @pkazmier, who found the problem and made the case for `bg5` over `bg4`.

`test/smoke.lua` passes.
