### PR TITLE
feat(groups): give netrw's own groups the roles they already have

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ theme = cendre
 
 Inside the editor, these get groups of their own rather than whatever their
 defaults land on: gitsigns, blink.cmp, Snacks, fzf-lua, which-key, Noice,
-neo-tree, nvim-tree, flash, trouble, lazy.nvim, mason, nvim-dap and dap-ui,
+neo-tree, nvim-tree, netrw, flash, trouble, lazy.nvim, mason, nvim-dap and dap-ui,
 neotest, mini.indentscope, mini.hipatterns, hlchunk, grug-far, diffview,
 illuminate, treesitter-context and rainbow-delimiters.
 

--- a/doc/cendre.txt
+++ b/doc/cendre.txt
@@ -302,7 +302,7 @@ qualified per depth, or installing two of them collides on one entry.
 
 Inside the editor, these carry groups of their own rather than whatever their
 defaults land on: gitsigns, blink.cmp, Snacks, fzf-lua, which-key, Noice,
-neo-tree, nvim-tree, flash, trouble, lazy.nvim, mason, nvim-dap and dap-ui,
+neo-tree, nvim-tree, netrw, flash, trouble, lazy.nvim, mason, nvim-dap and dap-ui,
 neotest, mini.indentscope, mini.hipatterns, hlchunk, grug-far, diffview,
 illuminate, treesitter-context and rainbow-delimiters.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1262,7 +1262,7 @@ footer b { color: var(--ember); font-weight: inherit; }
     </div>
     <p class="note gap-sm">Inside the editor, these carry groups of their own rather than whatever
       their defaults land on: gitsigns, blink.cmp, Snacks, fzf-lua, which-key, Noice, neo-tree,
-      nvim-tree, flash, trouble, lazy.nvim, mason, nvim-dap and dap-ui, neotest, mini.indentscope,
+      nvim-tree, netrw, flash, trouble, lazy.nvim, mason, nvim-dap and dap-ui, neotest, mini.indentscope,
       mini.hipatterns, hlchunk, grug-far, diffview, illuminate, treesitter-context and
       rainbow-delimiters.</p>
     <div class="scroll">

--- a/lua/cendre/groups/editor.lua
+++ b/lua/cendre/groups/editor.lua
@@ -72,6 +72,10 @@ function M.get(c)
     qfLineNr     = { fg = c.gutter },
     qfFileName   = { fg = c.frost },
 
+    netrwTreeBar  = { fg = c.bg4 },
+    netrwMarkFile = { bg = c.bg2, bold = true },
+    netrwClassify = { fg = c.comment },
+
     DiffAdd      = { bg = c.add },
     DiffDelete   = { bg = c.del },
     DiffChange   = { bg = c.mod },


### PR DESCRIPTION
netrw links every group of its own to a syntax colour, so the theme was deciding how the file explorer looks without ever naming it.

| group | inherited from | rendered as | role it fills |
|---|---|---|---|
| `netrwTreeBar` | `Special` | ember | structure |
| `netrwMarkFile` | `TabLineSel` | `fg` on `bg0` | selection |
| `netrwClassify` | `Function` | brass | marker |

The tree guides came out on the accent, which is the same job `MiniIndentscopeSymbol` and `SnacksIndentScope` do at `bg4`. A marked row landed on `bg0`, the editor ground, so it had no visible fill at all, which is the same shape as the selected-row bug fixed in #64. And the trailing `/` and `@` markers wore the colour of a function call.

Each one now takes what its role already wears elsewhere in the theme:

```lua
netrwTreeBar  = { fg = c.bg4 },
netrwMarkFile = { bg = c.bg2, bold = true },
netrwClassify = { fg = c.comment },
```

Everything else keeps inheriting, `netrwDir` through `Directory` included, since those land on the right colour already.

## Why it matters

Zero-plugin configs on nvim 0.11+ use netrw as their file tree, and a user seeing orange tree guides has no way to guess the cause is `Special`. netrw moved to `pack/dist/opt` in 0.12 but `plugin/netrwPlugin.vim` still `packadd`s it, so it is loaded out of the box and this applies to every version.

## Verified

Group names read from the `syntax/netrw.vim` nvim ships, not from memory. Resolved in a real netrw buffer: `0x463e3a`, `0x2a2422`, `0x73665b`.

`test/smoke.lua` passes.
