### PR TITLE
feat(helix): cover the scopes Helix reads and cendre left to inherit

### DIFF
--- a/extras/helix/cendre-medium.toml
+++ b/extras/helix/cendre-medium.toml
@@ -4,7 +4,8 @@
 # Install: copy to ~/.config/helix/themes/cendre.toml, then set
 # `theme = "cendre-medium"` in ~/.config/helix/config.toml.
 
-# syntax
+# syntax. Helix falls back on the longest prefix it has a rule for, so a scope is
+# only named here when inheriting would hand it the wrong pigment.
 "keyword" = "cinder"
 "keyword.control" = "cinder"
 "keyword.directive" = "cinder"
@@ -26,6 +27,10 @@
 "string" = "sap"
 "string.regexp" = "ember"
 "string.special" = "ember"
+# a path or a url points somewhere, which is the frost job, so the two step out
+# of the ember family the rest of string.special sits in
+"string.special.path" = "frost"
+"string.special.url" = { fg = "frost", modifiers = ["underlined"] }
 "comment" = { fg = "comment", modifiers = ["italic"] }
 "variable" = "fg"
 "variable.builtin" = "cinder"
@@ -37,14 +42,28 @@
 "punctuation" = "fg_dim"
 "punctuation.delimiter" = "fg_dim"
 "punctuation.bracket" = "fg_dim"
+# interpolation braces and format specifiers carry meaning a comma does not
+"punctuation.special" = "ember"
 "special" = "ember"
 "tag" = "cinder"
+"tabstop" = { bg = "bg2" }
 
-# markup
+# markup. Six heading levels out of five pigments, so the last one steps down to
+# fg_dim rather than repeating a pigment.
 "markup.heading" = { fg = "ember", modifiers = ["bold"] }
+"markup.heading.1" = { fg = "ember", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "brass", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "frost", modifiers = ["bold"] }
+"markup.heading.4" = { fg = "sap", modifiers = ["bold"] }
+"markup.heading.5" = { fg = "cinder", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "fg_dim", modifiers = ["bold"] }
 "markup.list" = "ember"
+"markup.list.checked" = "ok"
+"markup.list.unchecked" = "comment"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link" = "frost"
 "markup.link.url" = { fg = "comment", modifiers = ["underlined"] }
 "markup.link.text" = "frost"
 "markup.quote" = { fg = "comment", modifiers = ["italic"] }
@@ -52,31 +71,66 @@
 
 # ui
 "ui.background" = { bg = "bg0" }
+"ui.background.separator" = "bg3"
 "ui.text" = "fg"
 "ui.text.focus" = { fg = "fg", modifiers = ["bold"] }
+"ui.text.inactive" = "comment"
+"ui.text.info" = "fg_dim"
+"ui.text.directory" = "frost"
+# the cursor answers to the mode, on the same three pigments the statusline uses,
+# so the block under your hand and the badge in the corner never disagree
 "ui.cursor" = { fg = "bg0", bg = "ember" }
+"ui.cursor.normal" = { fg = "bg0", bg = "ember" }
+"ui.cursor.insert" = { fg = "bg0", bg = "ok" }
+"ui.cursor.select" = { fg = "bg0", bg = "info" }
 "ui.cursor.primary" = { fg = "bg0", bg = "ember" }
+"ui.cursor.primary.normal" = { fg = "bg0", bg = "ember" }
+"ui.cursor.primary.insert" = { fg = "bg0", bg = "ok" }
+"ui.cursor.primary.select" = { fg = "bg0", bg = "info" }
 "ui.cursor.match" = { fg = "ember", modifiers = ["bold"] }
 "ui.cursorline.primary" = { bg = "bg1" }
-"ui.selection" = { bg = "vis" }
+"ui.cursorline.secondary" = { bg = "bg1" }
+"ui.cursorcolumn.primary" = { bg = "bg1" }
+"ui.cursorcolumn.secondary" = { bg = "bg1" }
+# the warm tint marks the selection you are driving. The rest take plain ground,
+# one step darker, because with thirty cursors down a file every one of them
+# cannot be the one, and hue alone does not carry that at this chroma.
+"ui.selection" = { bg = "bg1" }
+"ui.selection.primary" = { bg = "vis" }
 "ui.linenr" = "gutter"
 "ui.linenr.selected" = { fg = "ember", modifiers = ["bold"] }
+# the gutter takes the cursorline too, or the band stops where the text starts
+"ui.gutter" = { bg = "bg0" }
+"ui.gutter.selected" = { bg = "bg1" }
 "ui.statusline" = { fg = "fg_dim", bg = "bg2" }
 "ui.statusline.inactive" = { fg = "gutter", bg = "bg1" }
 "ui.statusline.normal" = { fg = "bg0", bg = "ember", modifiers = ["bold"] }
 "ui.statusline.insert" = { fg = "bg0", bg = "ok", modifiers = ["bold"] }
 "ui.statusline.select" = { fg = "bg0", bg = "info", modifiers = ["bold"] }
+"ui.statusline.separator" = { fg = "bg3", bg = "bg2" }
 "ui.bufferline" = { fg = "comment", bg = "bg1" }
 "ui.bufferline.active" = { fg = "fg", bg = "bg0", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "bg1" }
 "ui.popup" = { fg = "fg", bg = "bg_deep" }
 "ui.window" = { fg = "bg3" }
 "ui.help" = { fg = "fg", bg = "bg_deep" }
 "ui.menu" = { fg = "fg", bg = "bg1" }
 "ui.menu.selected" = { fg = "bg0", bg = "ember", modifiers = ["bold"] }
+"ui.menu.scroll" = { fg = "bg4", bg = "bg2" }
+"ui.picker.header" = "comment"
+"ui.picker.header.column.active" = { fg = "ember", modifiers = ["bold"] }
 "ui.virtual.whitespace" = "bg3"
 "ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.indent-guide" = "bg2"
+"ui.virtual.wrap" = "bg3"
 "ui.virtual.inlay-hint" = { fg = "gutter", modifiers = ["italic"] }
+# a jump label is read in the time it takes to type it, so it gets the loudest
+# pair the theme has rather than a pigment on the ground
+"ui.virtual.jump-label" = { fg = "bg0", bg = "ember", modifiers = ["bold"] }
 "ui.highlight" = { bg = "bg2" }
+"ui.highlight.frameline" = { bg = "bg2" }
+"ui.debug.breakpoint" = "error"
+"ui.debug.active" = "warn"
 
 # diagnostics, their own family
 "error" = "error"
@@ -87,11 +141,18 @@
 "diagnostic.warning" = { underline = { color = "warn", style = "curl" } }
 "diagnostic.info" = { underline = { color = "info", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "hint", style = "curl" } }
+# dead and dying code says what it is by receding, so neither takes a curl
+"diagnostic.unnecessary" = { fg = "gutter" }
+"diagnostic.deprecated" = { fg = "comment", modifiers = ["crossed_out"] }
 
 # diff
 "diff.plus" = "ok"
+"diff.plus.gutter" = "ok"
 "diff.minus" = "error"
+"diff.minus.gutter" = "error"
 "diff.delta" = "info"
+"diff.delta.gutter" = "info"
+"diff.delta.conflict" = "warn"
 
 [palette]
 bg_deep = "#141110"

--- a/extras/helix/cendre-soft.toml
+++ b/extras/helix/cendre-soft.toml
@@ -4,7 +4,8 @@
 # Install: copy to ~/.config/helix/themes/cendre.toml, then set
 # `theme = "cendre-soft"` in ~/.config/helix/config.toml.
 
-# syntax
+# syntax. Helix falls back on the longest prefix it has a rule for, so a scope is
+# only named here when inheriting would hand it the wrong pigment.
 "keyword" = "cinder"
 "keyword.control" = "cinder"
 "keyword.directive" = "cinder"
@@ -26,6 +27,10 @@
 "string" = "sap"
 "string.regexp" = "ember"
 "string.special" = "ember"
+# a path or a url points somewhere, which is the frost job, so the two step out
+# of the ember family the rest of string.special sits in
+"string.special.path" = "frost"
+"string.special.url" = { fg = "frost", modifiers = ["underlined"] }
 "comment" = { fg = "comment", modifiers = ["italic"] }
 "variable" = "fg"
 "variable.builtin" = "cinder"
@@ -37,14 +42,28 @@
 "punctuation" = "fg_dim"
 "punctuation.delimiter" = "fg_dim"
 "punctuation.bracket" = "fg_dim"
+# interpolation braces and format specifiers carry meaning a comma does not
+"punctuation.special" = "ember"
 "special" = "ember"
 "tag" = "cinder"
+"tabstop" = { bg = "bg2" }
 
-# markup
+# markup. Six heading levels out of five pigments, so the last one steps down to
+# fg_dim rather than repeating a pigment.
 "markup.heading" = { fg = "ember", modifiers = ["bold"] }
+"markup.heading.1" = { fg = "ember", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "brass", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "frost", modifiers = ["bold"] }
+"markup.heading.4" = { fg = "sap", modifiers = ["bold"] }
+"markup.heading.5" = { fg = "cinder", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "fg_dim", modifiers = ["bold"] }
 "markup.list" = "ember"
+"markup.list.checked" = "ok"
+"markup.list.unchecked" = "comment"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link" = "frost"
 "markup.link.url" = { fg = "comment", modifiers = ["underlined"] }
 "markup.link.text" = "frost"
 "markup.quote" = { fg = "comment", modifiers = ["italic"] }
@@ -52,31 +71,66 @@
 
 # ui
 "ui.background" = { bg = "bg0" }
+"ui.background.separator" = "bg3"
 "ui.text" = "fg"
 "ui.text.focus" = { fg = "fg", modifiers = ["bold"] }
+"ui.text.inactive" = "comment"
+"ui.text.info" = "fg_dim"
+"ui.text.directory" = "frost"
+# the cursor answers to the mode, on the same three pigments the statusline uses,
+# so the block under your hand and the badge in the corner never disagree
 "ui.cursor" = { fg = "bg0", bg = "ember" }
+"ui.cursor.normal" = { fg = "bg0", bg = "ember" }
+"ui.cursor.insert" = { fg = "bg0", bg = "ok" }
+"ui.cursor.select" = { fg = "bg0", bg = "info" }
 "ui.cursor.primary" = { fg = "bg0", bg = "ember" }
+"ui.cursor.primary.normal" = { fg = "bg0", bg = "ember" }
+"ui.cursor.primary.insert" = { fg = "bg0", bg = "ok" }
+"ui.cursor.primary.select" = { fg = "bg0", bg = "info" }
 "ui.cursor.match" = { fg = "ember", modifiers = ["bold"] }
 "ui.cursorline.primary" = { bg = "bg1" }
-"ui.selection" = { bg = "vis" }
+"ui.cursorline.secondary" = { bg = "bg1" }
+"ui.cursorcolumn.primary" = { bg = "bg1" }
+"ui.cursorcolumn.secondary" = { bg = "bg1" }
+# the warm tint marks the selection you are driving. The rest take plain ground,
+# one step darker, because with thirty cursors down a file every one of them
+# cannot be the one, and hue alone does not carry that at this chroma.
+"ui.selection" = { bg = "bg1" }
+"ui.selection.primary" = { bg = "vis" }
 "ui.linenr" = "gutter"
 "ui.linenr.selected" = { fg = "ember", modifiers = ["bold"] }
+# the gutter takes the cursorline too, or the band stops where the text starts
+"ui.gutter" = { bg = "bg0" }
+"ui.gutter.selected" = { bg = "bg1" }
 "ui.statusline" = { fg = "fg_dim", bg = "bg2" }
 "ui.statusline.inactive" = { fg = "gutter", bg = "bg1" }
 "ui.statusline.normal" = { fg = "bg0", bg = "ember", modifiers = ["bold"] }
 "ui.statusline.insert" = { fg = "bg0", bg = "ok", modifiers = ["bold"] }
 "ui.statusline.select" = { fg = "bg0", bg = "info", modifiers = ["bold"] }
+"ui.statusline.separator" = { fg = "bg3", bg = "bg2" }
 "ui.bufferline" = { fg = "comment", bg = "bg1" }
 "ui.bufferline.active" = { fg = "fg", bg = "bg0", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "bg1" }
 "ui.popup" = { fg = "fg", bg = "bg_deep" }
 "ui.window" = { fg = "bg3" }
 "ui.help" = { fg = "fg", bg = "bg_deep" }
 "ui.menu" = { fg = "fg", bg = "bg1" }
 "ui.menu.selected" = { fg = "bg0", bg = "ember", modifiers = ["bold"] }
+"ui.menu.scroll" = { fg = "bg4", bg = "bg2" }
+"ui.picker.header" = "comment"
+"ui.picker.header.column.active" = { fg = "ember", modifiers = ["bold"] }
 "ui.virtual.whitespace" = "bg3"
 "ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.indent-guide" = "bg2"
+"ui.virtual.wrap" = "bg3"
 "ui.virtual.inlay-hint" = { fg = "gutter", modifiers = ["italic"] }
+# a jump label is read in the time it takes to type it, so it gets the loudest
+# pair the theme has rather than a pigment on the ground
+"ui.virtual.jump-label" = { fg = "bg0", bg = "ember", modifiers = ["bold"] }
 "ui.highlight" = { bg = "bg2" }
+"ui.highlight.frameline" = { bg = "bg2" }
+"ui.debug.breakpoint" = "error"
+"ui.debug.active" = "warn"
 
 # diagnostics, their own family
 "error" = "error"
@@ -87,11 +141,18 @@
 "diagnostic.warning" = { underline = { color = "warn", style = "curl" } }
 "diagnostic.info" = { underline = { color = "info", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "hint", style = "curl" } }
+# dead and dying code says what it is by receding, so neither takes a curl
+"diagnostic.unnecessary" = { fg = "gutter" }
+"diagnostic.deprecated" = { fg = "comment", modifiers = ["crossed_out"] }
 
 # diff
 "diff.plus" = "ok"
+"diff.plus.gutter" = "ok"
 "diff.minus" = "error"
+"diff.minus.gutter" = "error"
 "diff.delta" = "info"
+"diff.delta.gutter" = "info"
+"diff.delta.conflict" = "warn"
 
 [palette]
 bg_deep = "#1a1716"

--- a/extras/helix/cendre.toml
+++ b/extras/helix/cendre.toml
@@ -4,7 +4,8 @@
 # Install: copy to ~/.config/helix/themes/cendre.toml, then set
 # `theme = "cendre"` in ~/.config/helix/config.toml.
 
-# syntax
+# syntax. Helix falls back on the longest prefix it has a rule for, so a scope is
+# only named here when inheriting would hand it the wrong pigment.
 "keyword" = "cinder"
 "keyword.control" = "cinder"
 "keyword.directive" = "cinder"
@@ -26,6 +27,10 @@
 "string" = "sap"
 "string.regexp" = "ember"
 "string.special" = "ember"
+# a path or a url points somewhere, which is the frost job, so the two step out
+# of the ember family the rest of string.special sits in
+"string.special.path" = "frost"
+"string.special.url" = { fg = "frost", modifiers = ["underlined"] }
 "comment" = { fg = "comment", modifiers = ["italic"] }
 "variable" = "fg"
 "variable.builtin" = "cinder"
@@ -37,14 +42,28 @@
 "punctuation" = "fg_dim"
 "punctuation.delimiter" = "fg_dim"
 "punctuation.bracket" = "fg_dim"
+# interpolation braces and format specifiers carry meaning a comma does not
+"punctuation.special" = "ember"
 "special" = "ember"
 "tag" = "cinder"
+"tabstop" = { bg = "bg2" }
 
-# markup
+# markup. Six heading levels out of five pigments, so the last one steps down to
+# fg_dim rather than repeating a pigment.
 "markup.heading" = { fg = "ember", modifiers = ["bold"] }
+"markup.heading.1" = { fg = "ember", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "brass", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "frost", modifiers = ["bold"] }
+"markup.heading.4" = { fg = "sap", modifiers = ["bold"] }
+"markup.heading.5" = { fg = "cinder", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "fg_dim", modifiers = ["bold"] }
 "markup.list" = "ember"
+"markup.list.checked" = "ok"
+"markup.list.unchecked" = "comment"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link" = "frost"
 "markup.link.url" = { fg = "comment", modifiers = ["underlined"] }
 "markup.link.text" = "frost"
 "markup.quote" = { fg = "comment", modifiers = ["italic"] }
@@ -52,31 +71,66 @@
 
 # ui
 "ui.background" = { bg = "bg0" }
+"ui.background.separator" = "bg3"
 "ui.text" = "fg"
 "ui.text.focus" = { fg = "fg", modifiers = ["bold"] }
+"ui.text.inactive" = "comment"
+"ui.text.info" = "fg_dim"
+"ui.text.directory" = "frost"
+# the cursor answers to the mode, on the same three pigments the statusline uses,
+# so the block under your hand and the badge in the corner never disagree
 "ui.cursor" = { fg = "bg0", bg = "ember" }
+"ui.cursor.normal" = { fg = "bg0", bg = "ember" }
+"ui.cursor.insert" = { fg = "bg0", bg = "ok" }
+"ui.cursor.select" = { fg = "bg0", bg = "info" }
 "ui.cursor.primary" = { fg = "bg0", bg = "ember" }
+"ui.cursor.primary.normal" = { fg = "bg0", bg = "ember" }
+"ui.cursor.primary.insert" = { fg = "bg0", bg = "ok" }
+"ui.cursor.primary.select" = { fg = "bg0", bg = "info" }
 "ui.cursor.match" = { fg = "ember", modifiers = ["bold"] }
 "ui.cursorline.primary" = { bg = "bg1" }
-"ui.selection" = { bg = "vis" }
+"ui.cursorline.secondary" = { bg = "bg1" }
+"ui.cursorcolumn.primary" = { bg = "bg1" }
+"ui.cursorcolumn.secondary" = { bg = "bg1" }
+# the warm tint marks the selection you are driving. The rest take plain ground,
+# one step darker, because with thirty cursors down a file every one of them
+# cannot be the one, and hue alone does not carry that at this chroma.
+"ui.selection" = { bg = "bg1" }
+"ui.selection.primary" = { bg = "vis" }
 "ui.linenr" = "gutter"
 "ui.linenr.selected" = { fg = "ember", modifiers = ["bold"] }
+# the gutter takes the cursorline too, or the band stops where the text starts
+"ui.gutter" = { bg = "bg0" }
+"ui.gutter.selected" = { bg = "bg1" }
 "ui.statusline" = { fg = "fg_dim", bg = "bg2" }
 "ui.statusline.inactive" = { fg = "gutter", bg = "bg1" }
 "ui.statusline.normal" = { fg = "bg0", bg = "ember", modifiers = ["bold"] }
 "ui.statusline.insert" = { fg = "bg0", bg = "ok", modifiers = ["bold"] }
 "ui.statusline.select" = { fg = "bg0", bg = "info", modifiers = ["bold"] }
+"ui.statusline.separator" = { fg = "bg3", bg = "bg2" }
 "ui.bufferline" = { fg = "comment", bg = "bg1" }
 "ui.bufferline.active" = { fg = "fg", bg = "bg0", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "bg1" }
 "ui.popup" = { fg = "fg", bg = "bg_deep" }
 "ui.window" = { fg = "bg3" }
 "ui.help" = { fg = "fg", bg = "bg_deep" }
 "ui.menu" = { fg = "fg", bg = "bg1" }
 "ui.menu.selected" = { fg = "bg0", bg = "ember", modifiers = ["bold"] }
+"ui.menu.scroll" = { fg = "bg4", bg = "bg2" }
+"ui.picker.header" = "comment"
+"ui.picker.header.column.active" = { fg = "ember", modifiers = ["bold"] }
 "ui.virtual.whitespace" = "bg3"
 "ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.indent-guide" = "bg2"
+"ui.virtual.wrap" = "bg3"
 "ui.virtual.inlay-hint" = { fg = "gutter", modifiers = ["italic"] }
+# a jump label is read in the time it takes to type it, so it gets the loudest
+# pair the theme has rather than a pigment on the ground
+"ui.virtual.jump-label" = { fg = "bg0", bg = "ember", modifiers = ["bold"] }
 "ui.highlight" = { bg = "bg2" }
+"ui.highlight.frameline" = { bg = "bg2" }
+"ui.debug.breakpoint" = "error"
+"ui.debug.active" = "warn"
 
 # diagnostics, their own family
 "error" = "error"
@@ -87,11 +141,18 @@
 "diagnostic.warning" = { underline = { color = "warn", style = "curl" } }
 "diagnostic.info" = { underline = { color = "info", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "hint", style = "curl" } }
+# dead and dying code says what it is by receding, so neither takes a curl
+"diagnostic.unnecessary" = { fg = "gutter" }
+"diagnostic.deprecated" = { fg = "comment", modifiers = ["crossed_out"] }
 
 # diff
 "diff.plus" = "ok"
+"diff.plus.gutter" = "ok"
 "diff.minus" = "error"
+"diff.minus.gutter" = "error"
 "diff.delta" = "info"
+"diff.delta.gutter" = "info"
+"diff.delta.conflict" = "warn"
 
 [palette]
 bg_deep = "#0f0c0a"

--- a/lua/cendre/extras/editors.lua
+++ b/lua/cendre/extras/editors.lua
@@ -140,7 +140,8 @@ function M.helix(bg)
 # Install: copy to ~/.config/helix/themes/cendre.toml, then set
 # `theme = "%s"` in ~/.config/helix/config.toml.
 
-# syntax
+# syntax. Helix falls back on the longest prefix it has a rule for, so a scope is
+# only named here when inheriting would hand it the wrong pigment.
 "keyword" = "cinder"
 "keyword.control" = "cinder"
 "keyword.directive" = "cinder"
@@ -162,6 +163,10 @@ function M.helix(bg)
 "string" = "sap"
 "string.regexp" = "ember"
 "string.special" = "ember"
+# a path or a url points somewhere, which is the frost job, so the two step out
+# of the ember family the rest of string.special sits in
+"string.special.path" = "frost"
+"string.special.url" = { fg = "frost", modifiers = ["underlined"] }
 "comment" = { fg = "comment", modifiers = ["italic"] }
 "variable" = "fg"
 "variable.builtin" = "cinder"
@@ -173,14 +178,28 @@ function M.helix(bg)
 "punctuation" = "fg_dim"
 "punctuation.delimiter" = "fg_dim"
 "punctuation.bracket" = "fg_dim"
+# interpolation braces and format specifiers carry meaning a comma does not
+"punctuation.special" = "ember"
 "special" = "ember"
 "tag" = "cinder"
+"tabstop" = { bg = "bg2" }
 
-# markup
+# markup. Six heading levels out of five pigments, so the last one steps down to
+# fg_dim rather than repeating a pigment.
 "markup.heading" = { fg = "ember", modifiers = ["bold"] }
+"markup.heading.1" = { fg = "ember", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "brass", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "frost", modifiers = ["bold"] }
+"markup.heading.4" = { fg = "sap", modifiers = ["bold"] }
+"markup.heading.5" = { fg = "cinder", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "fg_dim", modifiers = ["bold"] }
 "markup.list" = "ember"
+"markup.list.checked" = "ok"
+"markup.list.unchecked" = "comment"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link" = "frost"
 "markup.link.url" = { fg = "comment", modifiers = ["underlined"] }
 "markup.link.text" = "frost"
 "markup.quote" = { fg = "comment", modifiers = ["italic"] }
@@ -188,31 +207,66 @@ function M.helix(bg)
 
 # ui
 "ui.background" = { bg = "bg0" }
+"ui.background.separator" = "bg3"
 "ui.text" = "fg"
 "ui.text.focus" = { fg = "fg", modifiers = ["bold"] }
+"ui.text.inactive" = "comment"
+"ui.text.info" = "fg_dim"
+"ui.text.directory" = "frost"
+# the cursor answers to the mode, on the same three pigments the statusline uses,
+# so the block under your hand and the badge in the corner never disagree
 "ui.cursor" = { fg = "bg0", bg = "ember" }
+"ui.cursor.normal" = { fg = "bg0", bg = "ember" }
+"ui.cursor.insert" = { fg = "bg0", bg = "ok" }
+"ui.cursor.select" = { fg = "bg0", bg = "info" }
 "ui.cursor.primary" = { fg = "bg0", bg = "ember" }
+"ui.cursor.primary.normal" = { fg = "bg0", bg = "ember" }
+"ui.cursor.primary.insert" = { fg = "bg0", bg = "ok" }
+"ui.cursor.primary.select" = { fg = "bg0", bg = "info" }
 "ui.cursor.match" = { fg = "ember", modifiers = ["bold"] }
 "ui.cursorline.primary" = { bg = "bg1" }
-"ui.selection" = { bg = "vis" }
+"ui.cursorline.secondary" = { bg = "bg1" }
+"ui.cursorcolumn.primary" = { bg = "bg1" }
+"ui.cursorcolumn.secondary" = { bg = "bg1" }
+# the warm tint marks the selection you are driving. The rest take plain ground,
+# one step darker, because with thirty cursors down a file every one of them
+# cannot be the one, and hue alone does not carry that at this chroma.
+"ui.selection" = { bg = "bg1" }
+"ui.selection.primary" = { bg = "vis" }
 "ui.linenr" = "gutter"
 "ui.linenr.selected" = { fg = "ember", modifiers = ["bold"] }
+# the gutter takes the cursorline too, or the band stops where the text starts
+"ui.gutter" = { bg = "bg0" }
+"ui.gutter.selected" = { bg = "bg1" }
 "ui.statusline" = { fg = "fg_dim", bg = "bg2" }
 "ui.statusline.inactive" = { fg = "gutter", bg = "bg1" }
 "ui.statusline.normal" = { fg = "bg0", bg = "ember", modifiers = ["bold"] }
 "ui.statusline.insert" = { fg = "bg0", bg = "ok", modifiers = ["bold"] }
 "ui.statusline.select" = { fg = "bg0", bg = "info", modifiers = ["bold"] }
+"ui.statusline.separator" = { fg = "bg3", bg = "bg2" }
 "ui.bufferline" = { fg = "comment", bg = "bg1" }
 "ui.bufferline.active" = { fg = "fg", bg = "bg0", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "bg1" }
 "ui.popup" = { fg = "fg", bg = "bg_deep" }
 "ui.window" = { fg = "bg3" }
 "ui.help" = { fg = "fg", bg = "bg_deep" }
 "ui.menu" = { fg = "fg", bg = "bg1" }
 "ui.menu.selected" = { fg = "bg0", bg = "ember", modifiers = ["bold"] }
+"ui.menu.scroll" = { fg = "bg4", bg = "bg2" }
+"ui.picker.header" = "comment"
+"ui.picker.header.column.active" = { fg = "ember", modifiers = ["bold"] }
 "ui.virtual.whitespace" = "bg3"
 "ui.virtual.ruler" = { bg = "bg1" }
+"ui.virtual.indent-guide" = "bg2"
+"ui.virtual.wrap" = "bg3"
 "ui.virtual.inlay-hint" = { fg = "gutter", modifiers = ["italic"] }
+# a jump label is read in the time it takes to type it, so it gets the loudest
+# pair the theme has rather than a pigment on the ground
+"ui.virtual.jump-label" = { fg = "bg0", bg = "ember", modifiers = ["bold"] }
 "ui.highlight" = { bg = "bg2" }
+"ui.highlight.frameline" = { bg = "bg2" }
+"ui.debug.breakpoint" = "error"
+"ui.debug.active" = "warn"
 
 # diagnostics, their own family
 "error" = "error"
@@ -223,11 +277,18 @@ function M.helix(bg)
 "diagnostic.warning" = { underline = { color = "warn", style = "curl" } }
 "diagnostic.info" = { underline = { color = "info", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "hint", style = "curl" } }
+# dead and dying code says what it is by receding, so neither takes a curl
+"diagnostic.unnecessary" = { fg = "gutter" }
+"diagnostic.deprecated" = { fg = "comment", modifiers = ["crossed_out"] }
 
 # diff
 "diff.plus" = "ok"
+"diff.plus.gutter" = "ok"
 "diff.minus" = "error"
+"diff.minus.gutter" = "error"
 "diff.delta" = "info"
+"diff.delta.gutter" = "info"
+"diff.delta.conflict" = "warn"
 
 [palette]
 bg_deep = "%s"


### PR DESCRIPTION
`extras/helix/` set **83 of the ~170 scopes** Helix exposes. It sets **126** now.

## Wrong, not just missing

Most of the gaps inherited the right pigment by prefix, so they needed nothing. These did not:

| scope | was | now |
| --- | --- | --- |
| `string.special.path` | ember, via `string.special` | frost, as `@string.special.path` already is in Neovim |
| `string.special.url` | ember | frost, underlined |
| `punctuation.special` | fg_dim, via `punctuation` | ember, as `@punctuation.special` already is |
| `markup.heading.1` … `.6` | one ember for all six | the six the Neovim groups define |

## Invisible

Three scopes were unset in a way you could see:

- **`ui.selection.primary`** — with multiple cursors, the one you drive looked like the ones you do not.
- **`ui.gutter.selected`** — the cursorline band stopped where the text started.
- **`ui.virtual.jump-label`** — `gw` labels took the terminal default.

## Added

Everything below follows the Neovim groups rather than inventing a second role map.

- Cursor answers to the mode (`ui.cursor.{normal,insert,select}` and the `.primary.*` set), on the ember/ok/info the statusline already used.
- `ui.cursorline.secondary`, `ui.cursorcolumn.{primary,secondary}`, `ui.virtual.{indent-guide,wrap}`.
- `ui.picker.header`, `.column.active`, `ui.text.{inactive,info,directory}`, `ui.menu.scroll`, `ui.statusline.separator`, `ui.bufferline.background`, `ui.background.separator`.
- `ui.debug.{breakpoint,active}` and `ui.highlight.frameline`, from the Dap groups.
- `diagnostic.unnecessary` (gutter) and `diagnostic.deprecated` (comment, crossed out), from `lua/cendre/groups/lsp.lua`.
- `diff.{plus,minus,delta}.gutter` and `diff.delta.conflict`, the last one warn, matching the Zed theme.
- `markup.strikethrough`, `markup.link`, `markup.list.{checked,unchecked}`, `tabstop`.

The remaining Helix scopes inherit the right pigment by prefix. There is a comment at the head of the syntax section saying so, so nobody adds them back as noise.

## Before / after

Helix 25.07.1, captured as raw ANSI out of tmux with truecolor forced on, then drawn cell by cell. The colours below are the bytes Helix wrote to the terminal.

**Six heading levels**

![markdown](https://raw.githubusercontent.com/Aejkatappaja/cendre/media/helix-scopes/media/ba-markdown.png)

**Four cursors, one of them yours**

![multicursor](https://raw.githubusercontent.com/Aejkatappaja/cendre/media/helix-scopes/media/ba-multicursor.png)

**The file picker**

![picker](https://raw.githubusercontent.com/Aejkatappaja/cendre/media/helix-scopes/media/ba-picker.png)

## One behaviour change

`ui.selection` moves from `vis` to `bg1`, and `ui.selection.primary` takes `vis`.

A single selection is the primary, so it looks exactly as it did. Only secondaries moved. `bg2` was the first attempt and it measured badly: the primary sat **0.012** below it in OKLCH lightness, so the one you were driving was the *darker* of the pair and hue was doing all the work. Against `bg1` the primary is both warmer and 0.027 lighter.

## Verification

- `test/smoke.lua` passes, including *the committed extras match a fresh render of the palette* and *no generated file carries a colour the palette does not define*.
- All three depths parse as TOML: 126 scopes, 22 palette entries each.
- `crossed_out`, `underlined` and the bare-string form checked against the Helix theme docs.

Only `lua/cendre/extras/editors.lua` is hand-edited. The three TOML files come from `scripts/extras.lua`.
