### PR TITLE
docs: name four surfaces the way their projects name them

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ error never wears the same red as a keyword.
 
 ## 29 surfaces, one palette
 
-Neovim is where this starts, not where it stops. Ghostty, kitty, wezterm, foot,
-Alacritty, Konsole, tmux, bat, delta, lazygit, yazi, eza, fzf, btop, starship,
-helix, Zed, Obsidian, Firefox, KDE Plasma and the rest, with the path each one installs to:
+Neovim is where this starts, not where it stops. Ghostty, kitty, WezTerm, foot,
+Alacritty, Konsole, tmux, bat, delta, lazygit, Yazi, eza, fzf, btop, Starship,
+Helix, Zed, Obsidian, Firefox, KDE Plasma and the rest, with the path each one installs to:
 [cendretheme.com/#surfaces](https://cendretheme.com/#surfaces).
 
 Nothing under `extras/` or `assets/` is written by hand, nor the favicon and share


### PR DESCRIPTION
The surface list in the README and the one on the landing page disagreed on how to spell four of the same tools.

| | README was | site says | project says |
| --- | --- | --- | --- |
| WezTerm | `wezterm` | `WezTerm` | WezTerm |
| Yazi | `yazi` | `Yazi` | Yazi |
| Starship | `starship` | `Starship` | Starship |
| Helix | `helix` | `Helix` | Helix |

The README moves, since the projects capitalise.

The other direction is left alone on purpose. `kitty`, `foot`, `delta`, `lazygit`, `bat`, `eza`, `fzf`, `btop` and `tmux` are lowercase in the README because that is how those projects write themselves, not because anyone forgot a shift key.

Which does leave the landing page capitalising four of them (`Kitty`, `Foot`, `Delta`, `Lazygit`) where it should not. That is a separate change to `docs/index.html` and it is not in here.

Text only, no generated file touched. `test/smoke.lua` passes.
