### PR TITLE
feat(config): dim the window you are not in

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ lualine picks it up with `options.theme = "cendre"`, or leave `"auto"`.
 | ----------------- | ---------- | -------------------------------------------------------- |
 | `background`      | `"hard"`   | ground depth: `hard`, `medium` or `soft`                  |
 | `transparent`     | `false`    | strips Normal, floats and the statusline; plugin windows follow |
+| `dim_inactive`    | `false`    | the window you are not in drops to `bg_deep`               |
 | `italic_virtual_text` | `false` | italics on inlay hints, ghost text, git blame, the dashboard footer |
 | `italic_comments` | `true`     | italics on comments, independently of the above             |
 | `on_colors`       | noop       | `function(colors)` mutates the palette before highlights  |
@@ -129,6 +130,13 @@ lualine picks it up with `options.theme = "cendre"`, or leave `"auto"`.
 
 The background is painted by default. The ash bed is a colour the theme derived,
 so it may as well be on screen.
+
+`dim_inactive` reuses `bg_deep`, the ground floats and sidebars already stand on,
+rather than inventing a shade for it: the theme already says "not the buffer you
+are editing" with that colour. The trade is that a file tree and a background
+split then share one ground, which is why it is off by default. `SignColumn` and
+`FoldColumn` stay at editor brightness regardless, since Neovim has no inactive
+variant for either.
 
 The two italic switches are independent, not one overriding the other, so
 `italic_virtual_text = false` on its own leaves comments italic. Set both to

--- a/doc/cendre.txt
+++ b/doc/cendre.txt
@@ -108,6 +108,24 @@ Accepts a table. Every key is optional; pass only what you want to change.
         too. blink draws no border of its own by default, `border` in its own
         options turns one on.
 
+    dim_inactive        boolean     default false
+
+        Drops `NormalNC`, the window you are not in, from the editor ground to
+        `bg_deep`. That rung already exists and already carries the meaning:
+        floats and sidebars stand on it, so the theme is saying "not the buffer
+        you are editing" with a colour it uses for exactly that elsewhere.
+
+        The cost is that a file tree and a background split then share one
+        ground. Off by default for that reason: it is worth the trade only if
+        you live in splits more than in a sidebar.
+
+        `SignColumn` and `FoldColumn` keep the editor ground even here, because
+        Neovim has no inactive variant for either. A dimmed window therefore
+        keeps a normal-weight gutter, and `WinSeparator` carries the editor
+        ground too. Nothing a colorscheme can reach fixes that.
+
+        `transparent = true` wins: there is no ground left to lower.
+
     italic_virtual_text boolean     default false
 
         Italics on the text the editor adds around yours: `LspInlayHint`,
@@ -331,7 +349,8 @@ them useful:
     1. the palette resolves for the chosen depth
     2. `on_colors` mutates it
     3. every highlight group is built from the result
-    4. `transparent` strips backgrounds, the italic switches apply
+    4. `dim_inactive` lowers `NormalNC`, `transparent` strips backgrounds,
+       the italic switches apply
     5. `on_highlights` runs, and wins
 
 So `on_colors` is for changing a colour everywhere at once, and

--- a/lua/cendre/init.lua
+++ b/lua/cendre/init.lua
@@ -6,6 +6,8 @@ M.config = {
   background = "hard",
   -- The ash bed is a colour the theme derived, so it may as well be on screen.
   transparent = false,
+  -- The window you are not in drops to bg_deep.
+  dim_inactive = false,
   -- Italics on the text the editor adds around yours: inlay hints, ghost text,
   -- git blame, Noice virtual text, the dashboard footer. No syntax role is italic
   -- at any setting, since every role already keeps a real gap from the others.
@@ -96,6 +98,10 @@ function M.load()
   local highlights = {}
   for _, mod in ipairs({ "editor", "syntax", "treesitter", "lsp", "integrations" }) do
     highlights = vim.tbl_extend("force", highlights, require("cendre.groups." .. mod).get(c))
+  end
+
+  if M.config.dim_inactive then
+    highlights.NormalNC.bg = c.bg_deep
   end
 
   if M.config.transparent then

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -113,6 +113,37 @@ check("transparent = true strips Normal bg", function()
   assert(vim.api.nvim_get_hl(0, { name = "Normal" }).bg == nil, "Normal bg not stripped")
 end)
 
+check("dim_inactive is off unless asked, so a split does not move on its own", function()
+  reload()
+  require("cendre").setup({})
+  require("cendre").load()
+  assert(vim.api.nvim_get_hl(0, { name = "NormalNC" }).bg
+      == vim.api.nvim_get_hl(0, { name = "Normal" }).bg,
+    "NormalNC left the editor ground without being asked")
+end)
+
+check("dim_inactive = true drops NormalNC to bg_deep at every depth", function()
+  for _, bg in ipairs(BACKGROUNDS) do
+    reload()
+    require("cendre").setup({ background = bg, dim_inactive = true })
+    require("cendre").load()
+    local want = tonumber(require("cendre.palette").grounds[bg].bg_deep:sub(2), 16)
+    assert(vim.api.nvim_get_hl(0, { name = "NormalNC" }).bg == want,
+      ("NormalNC on %s is not bg_deep"):format(bg))
+    assert(vim.api.nvim_get_hl(0, { name = "Normal" }).bg
+        == tonumber(require("cendre.palette").grounds[bg].bg0:sub(2), 16),
+      ("dim_inactive moved the active window on %s"):format(bg))
+  end
+end)
+
+check("transparent = true outranks dim_inactive", function()
+  reload()
+  require("cendre").setup({ transparent = true, dim_inactive = true })
+  require("cendre").load()
+  assert(vim.api.nvim_get_hl(0, { name = "NormalNC" }).bg == nil,
+    "dim_inactive repainted a ground transparent = true is meant to strip")
+end)
+
 check("every float edge is the same stroke", function()
   reload()
   local c = require("cendre.palette").get("hard")


### PR DESCRIPTION
Closes #71.

Neovim gives a colorscheme one lever for the inactive window, `NormalNC`, and it sat on the editor ground so a split never moved. It now drops to `bg_deep` when `dim_inactive` is on.

## Why `bg_deep`

Three grounds were on the table. All of them separate the two windows by roughly the same amount (ΔL 0.034 to 0.036), so separation was a tie and direction decided it.

| ground | L | separation | direction | lands on |
| --- | --- | --- | --- | --- |
| `bg_deep` | 0.157 | 0.034 | recedes | floats, sidebars |
| a new rung below it | 0.125 | 0.066 | recedes | nothing |
| `bg1` | 0.227 | 0.036 | approaches | the cursorline |

`bg_deep` already carries the meaning. Floats and sidebars stand on it, so the theme is saying "not the buffer you are editing" with a colour it uses for exactly that elsewhere. Darker is also what every theme shipping this option does, including the Catppuccin the issue cites.

A new rung below it collides with nothing, but lands at `#080605` on `hard`, close enough to black that the ash bed stops reading as a colour, and it adds an eighth value to a ladder whose comment justifies seven.

`bg1` is the only candidate that lowers text contrast rather than raising it, which is what receding actually means. It loses on meaning: the palette says lightness tracks distance from the heat, so lifting the inactive window moves it toward the fire, and `bg1` is the cursorline, so an inactive split takes the colour of the highlighted row next to it.

## Known limitation

`SignColumn` and `FoldColumn` are pinned to the editor ground and Neovim has no inactive variant for either, so a dimmed window keeps a normal-weight gutter. `WinSeparator` carries the editor ground too. Unpinning them would fix the seam and cost the gutter its identity under `transparent`, which is a separate decision and not taken here.

Off by default: a file tree and a background split then share one ground. `transparent = true` still wins, since there is no ground left to lower.

## Preview

<img width="4142" height="2054" alt="CleanShot 2026-08-07 at 1  22 39@2x" src="https://github.com/user-attachments/assets/f04a62d1-6e9f-4d5f-8189-bbcbbe8ea61e" />



## Tests

Three checks added, 64 pass:

- off unless asked, so a split does not move on its own
- `dim_inactive = true` drops `NormalNC` to `bg_deep` at all three depths, and leaves the active window alone
- `transparent = true` outranks it