### PR TITLE
fix(groups): name the groups Neovim ships with a colour of its own

### DIFF
--- a/lua/cendre/groups/editor.lua
+++ b/lua/cendre/groups/editor.lua
@@ -43,6 +43,9 @@ function M.get(c)
     PmenuBorder   = { fg = c.bg5, bg = c.bg_deep },
     PmenuSbar     = { bg = c.bg2 },
     PmenuThumb    = { bg = c.bg4 },
+    PreInsert     = { fg = c.gutter, italic = true },
+    FloatShadow        = { bg = c.bg_deep, blend = 80 },
+    FloatShadowThrough = { bg = c.bg_deep, blend = 100 },
     WildMenu      = { fg = c.bg0, bg = c.ember },
 
     StatusLine   = { fg = c.fg_dim, bg = c.bg2 },
@@ -61,6 +64,7 @@ function M.get(c)
     Question     = { fg = c.info },
     ErrorMsg     = { fg = c.error, bold = true },
     WarningMsg   = { fg = c.warn },
+    OkMsg        = { fg = c.ok },
     MsgArea      = { fg = c.fg_dim },
     MsgSeparator = { fg = c.bg3 },
 
@@ -91,6 +95,9 @@ function M.get(c)
     diffFile     = { fg = c.frost },
     diffLine     = { fg = c.comment },
     diffIndexLine = { fg = c.comment },
+    Added        = { fg = c.ok },
+    Removed      = { fg = c.error },
+    Changed      = { fg = c.info },
 
     SpellBad     = { undercurl = true, sp = c.error },
     SpellCap     = { undercurl = true, sp = c.warn },

--- a/lua/cendre/init.lua
+++ b/lua/cendre/init.lua
@@ -36,7 +36,7 @@ for _, name in ipairs({
 end
 for _, name in ipairs({
   "LspInlayHint", "BlinkCmpGhostText", "GitSignsCurrentLineBlame",
-  "NoiceVirtualText", "SnacksDashboardFooter",
+  "NoiceVirtualText", "SnacksDashboardFooter", "PreInsert",
 }) do
   ITALIC[name] = "virtual"
 end

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -656,6 +656,41 @@ check("the tmux plugin theme is mapped by role, not by ANSI name", function()
   end
 end)
 
+check("no group Neovim ships keeps a colour the palette does not define", function()
+  reload()
+  require("cendre").setup({})
+  require("cendre").load()
+
+  local palette = require("cendre.palette")
+  local known = {}
+  for _, bg in ipairs(palette.backgrounds) do
+    for _, v in pairs(palette.get(bg)) do
+      if type(v) == "string" and v:match("^#%x%x%x%x%x%x$") then known[v:lower()] = true end
+    end
+  end
+
+  -- Neovim defines a handful of groups with colours of its own, and a theme that
+  -- names none of them leaves them on screen: Added, Removed and Changed are what
+  -- @diff.plus, @diff.minus, @diff.delta and PreInsert link to, and vim.pack and
+  -- mini.deps paint with. Only the internal error and the redraw debug surfaces
+  -- are left alone, since they have to stay readable when the theme is the bug.
+  local theirs = { NvimInternalError = true }
+
+  local checked = 0
+  for name, hl in pairs(vim.api.nvim_get_hl(0, {})) do
+    if not theirs[name] and not name:match("^RedrawDebug") then
+      for _, key in ipairs({ "fg", "bg", "sp" }) do
+        if type(hl[key]) == "number" then
+          checked = checked + 1
+          assert(known[("#%06x"):format(hl[key])],
+            ("%s sets %s to #%06x, which the palette does not define"):format(name, key, hl[key]))
+        end
+      end
+    end
+  end
+  assert(checked > 300, "only " .. checked .. " colours checked, expected hundreds")
+end)
+
 check("no generated file carries a colour the palette does not define", function()
   reload()
   local palette = require("cendre.palette")


### PR DESCRIPTION
Neovim defines a few highlight groups with colours rather than links, and the theme named none of them, so they arrived on screen in Neovim's own palette.

- `Added`, `Removed`, `Changed` take `ok`, `error`, `info`. They are what `@diff.plus`, `@diff.minus`, `@diff.delta` and `PreInsert` link to, and what `vim.pack`'s update buffer and mini.deps paint with. Before this, every pending-update line was `#b3f6c0`.
- `PreInsert` takes the grey the other ghost text takes rather than inheriting `Added`, and joins the virtual family so it answers to `italic_virtual_text` like `BlinkCmpGhostText`.
- `OkMsg` takes `ok`.
- `FloatShadow` and `FloatShadowThrough` were `#4f5258`, a light grey, so a shadow lightened what it fell on. They take `bg_deep`. `PmenuShadow` and `PmenuShadowThrough` inherit them.

Four of the other groups new in 0.12 are deliberately left alone, because they already inherit: `DiffTextAdd` links to `DiffText`, `StderrMsg` to `ErrorMsg`, `SnippetTabstopActive` to `SnippetTabstop` to `Visual`, and `StdoutMsg` carries no colour at all.

The new check walks every group after a load and refuses a colour the palette does not define, which is what found these. `NvimInternalError` and the redraw debug surfaces stay out: they have to be readable when the theme is the thing that is broken.

Verified by rendering rather than by reading: the `vim.pack` update buffer, the `preinsert` ghost text and a float with `border = "shadow"`, before and after.