### PR TITLE
fix(lualine): drop the section ground when transparent is on

### DIFF
--- a/doc/cendre.txt
+++ b/doc/cendre.txt
@@ -108,6 +108,11 @@ Accepts a table. Every key is optional; pass only what you want to change.
         too. blink draws no border of its own by default, `border` in its own
         options turns one on.
 
+        The lualine theme drops its ground too, and keeps the mode block, which
+        is the one fill it ever draws. It reads this option once, when lualine
+        requires it, so `require("cendre").setup()` has to run before
+        `require("lualine").setup()` or the bar loads the painted variant.
+
     dim_inactive        boolean     default false
 
         Drops `NormalNC`, the window you are not in, from the editor ground to

--- a/lua/lualine/themes/cendre.lua
+++ b/lua/lualine/themes/cendre.lua
@@ -1,5 +1,6 @@
-local ok, cendre = pcall(require, "cendre")
-local c = require("cendre.palette").get(ok and cendre.config.background or "hard")
+local ok, mod = pcall(require, "cendre")
+local c = require("cendre.palette").get(ok and mod.config.background or "hard")
+local ground = (ok and mod.config.transparent) and "NONE" or c.bg2
 
 -- Mode colour tracks the semantic family, not the syntax pigments: the mode
 -- block should never look like a token.
@@ -8,11 +9,13 @@ local cendre = {}
 -- One ground for the whole bar, bg2, which is what this theme's own StatusLine
 -- group is set to: a lualine section painted in bg1 would contradict the
 -- statusline every other Neovim surface draws. Sections separate by ink weight,
--- fg against fg_dim, and the mode block is the only fill.
+-- fg against fg_dim, and the mode block is the only fill. Under `transparent`
+-- that ground drops out, the same way StatusLine does, or the bar paints a slab
+-- everywhere its components reach and leaves holes everywhere they do not.
 cendre.normal = {
   a = { fg = c.bg0, bg = c.ember, gui = "bold" },
-  b = { fg = c.fg, bg = c.bg2 },
-  c = { fg = c.fg_dim, bg = c.bg2 },
+  b = { fg = c.fg, bg = ground },
+  c = { fg = c.fg_dim, bg = ground },
 }
 
 cendre.insert = {
@@ -36,9 +39,9 @@ cendre.terminal = {
 }
 
 cendre.inactive = {
-  a = { fg = c.gutter, bg = c.bg2 },
-  b = { fg = c.gutter, bg = c.bg2 },
-  c = { fg = c.gutter, bg = c.bg2 },
+  a = { fg = c.gutter, bg = ground },
+  b = { fg = c.gutter, bg = ground },
+  c = { fg = c.gutter, bg = ground },
 }
 
 return cendre

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -1203,6 +1203,23 @@ check("lualine theme follows the active background", function()
     "lualine still on the wrong ground")
 end)
 
+-- A bar that keeps bg2 while StatusLine is stripped paints a slab under its own
+-- components and leaves the terminal showing everywhere else: navic's own groups,
+-- and the fill past the last section. The holes are the bug, not the transparency.
+check("lualine drops its ground with the rest of the statusline", function()
+  reload()
+  require("cendre").setup({ transparent = true })
+  require("cendre").load()
+  package.loaded["lualine.themes.cendre"] = nil
+  local theme = require("lualine.themes.cendre")
+  for _, section in ipairs({ theme.normal.b, theme.normal.c, theme.inactive.a,
+    theme.inactive.b, theme.inactive.c }) do
+    assert(section.bg == "NONE", "lualine paints " .. tostring(section.bg) .. " under transparent")
+  end
+  assert(theme.normal.a.bg == require("cendre.palette").get("hard").ember,
+    "the mode block is the one fill, and transparent does not reach it")
+end)
+
 -- The margin beside every pigment claims a hue, a lightness and a source. None of
 -- the three gets to be a comment nobody rechecks.
 local PIGMENTS = { "brass", "ember", "sap", "cinder", "frost" }


### PR DESCRIPTION
## What this changes

`transparent = true` now reaches the lualine theme. Sections `b` and `c`, and the whole inactive set, drop to `NONE` instead of being pinned to `bg2`. The mode block keeps its fill.

Before this, the two disagreed: `M.load()` stripped `StatusLine` to `NONE`, lualine kept painting `bg2`. The bar came out as a slab under the components lualine draws itself, and the terminal ground everywhere else. Two places show it, and both are normal setups rather than edge cases:

- nvim-navic emits its own `%#NavicIconsFunction#` / `%#NavicText#` groups. Those carry no `bg`, so the breadcrumb punched a dark rectangle through the middle of the bar.
- the fill past the last section falls back to `StatusLine`, so the right end of the bar was a second hole.

## Commit messages

- [x] Every commit follows `type(scope): subject`

`fix(lualine)`, one commit.

## If this touches colours

No colour changed. `bg2` is still the ground when `transparent` is off, and nothing under `extras/`, `assets/` or `docs/` moved.

## Verified

- [x] `smoke (stable)` passes locally, 60 checks

New check, `lualine drops its ground with the rest of the statusline`. It fails on `main` with the real value rather than a vague message:

```
FAIL - lualine drops its ground with the rest of the statusline:
       test/smoke.lua:1217: lualine paints #2a2422 under transparent
```

It also pins the mode block to `ember`, so a later "strip everything" does not quietly take the one fill the bar is meant to keep.

## Load order

The theme reads `cendre.config` once, when lualine requires it, so `require("cendre").setup()` has to run first or the bar loads the painted variant. That is now in `:help cendre-configuration` under `transparent`. It is a real sharp edge and I did not try to hide it behind an autocommand.
