### PR TITLE
feat(extras): cover Windows Terminal

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ Scopes in use: `palette`, `groups`, `extras`, `lualine`, `site`, `ci`.
 
 ## If this touches colours
 
-- [ ] Nothing under `extras/`, `assets/` or `docs/` was edited by hand. All 87
+- [ ] Nothing under `extras/`, `assets/` or `docs/` was edited by hand. All 96
       of those files are rendered from `lua/cendre/palette.lua`, and the test
       fails on any difference
 - [ ] Regenerated with the command in `CONTRIBUTING.md`, and the regenerated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 The one rule that will bite you if you skip it: **nothing under `extras/`,
-`assets/` or `docs/` is written by hand.** Those 87 files are rendered from
+`assets/` or `docs/` is written by hand.** Those 96 files are rendered from
 `lua/cendre/palette.lua`, and the test fails on any difference. Edit the
 generator, not the output.
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Neovim 0.9 or newer, with `termguicolors`.
 Diagnostics, git signs, diff and statusline draw from the semantic family. An
 error never wears the same red as a keyword.
 
-## 29 surfaces, one palette
+## 30 surfaces, one palette
 
 Neovim is where this starts, not where it stops. Ghostty, kitty, WezTerm, foot,
-Alacritty, Konsole, tmux, bat, delta, lazygit, Yazi, eza, fzf, btop, Starship,
-Helix, Zed, Obsidian, Firefox, KDE Plasma and the rest, with the path each one installs to:
+Alacritty, Konsole, Windows Terminal, tmux, bat, delta, lazygit, Yazi, eza, fzf,
+btop, Starship, Helix, Zed, Obsidian, Firefox, KDE Plasma and the rest, with the path each one installs to:
 [cendretheme.com/#surfaces](https://cendretheme.com/#surfaces).
 
 Nothing under `extras/` or `assets/` is written by hand, nor the favicon and share

--- a/docs/index.html
+++ b/docs/index.html
@@ -1267,7 +1267,7 @@ footer b { color: var(--ember); font-weight: inherit; }
       rainbow-delimiters.</p>
     <div class="scroll">
       <table class="surfaces">
-        <caption><span id="surface-count">29</span> surfaces · every file generated, never hand-edited</caption>
+        <caption><span id="surface-count">30</span> surfaces · every file generated, never hand-edited</caption>
         <thead>
           <tr><th scope="col">surface</th><th scope="col">lands in</th><th scope="col">command</th></tr>
         </thead>
@@ -2012,6 +2012,7 @@ const SURFACES = [
     ["Konsole", "colorschemes", "cp extras/konsole/cendre.colorscheme ~/.local/share/konsole/"],
     ["macOS Terminal", "import", "open extras/macos-terminal/cendre.terminal"],
     ["iTerm2", "Profiles, Colors", "import extras/macos-terminal/cendre.itermcolors"],
+    ["Windows Terminal", "Fragments", "copy extras/windows-terminal/cendre.json to %LOCALAPPDATA%\\Microsoft\\Windows Terminal\\Fragments\\cendre\\"],
   ]],
   ["Prompt and shell", [
     ["tmux", "config dir", "cp extras/tmux/cendre.tmux.conf ~/.config/tmux/"],

--- a/extras/windows-terminal/cendre-medium.json
+++ b/extras/windows-terminal/cendre-medium.json
@@ -1,0 +1,27 @@
+{
+  "schemes": [
+    {
+      "name": "cendre-medium",
+      "cursorColor": "#ea9875",
+      "selectionBackground": "#36241d",
+      "background": "#1d1917",
+      "foreground": "#e6d5c2",
+      "black": "#26211f",
+      "red": "#d1766e",
+      "green": "#99af6b",
+      "yellow": "#fcba81",
+      "blue": "#58bdff",
+      "purple": "#9480ba",
+      "cyan": "#4e89a2",
+      "white": "#a09384",
+      "brightBlack": "#73665b",
+      "brightRed": "#d25780",
+      "brightGreen": "#43b16a",
+      "brightYellow": "#f4a21c",
+      "brightBlue": "#8bcfff",
+      "brightPurple": "#a692cd",
+      "brightCyan": "#20c9cb",
+      "brightWhite": "#e6d5c2"
+    }
+  ]
+}

--- a/extras/windows-terminal/cendre-soft.json
+++ b/extras/windows-terminal/cendre-soft.json
@@ -1,0 +1,27 @@
+{
+  "schemes": [
+    {
+      "name": "cendre-soft",
+      "cursorColor": "#ea9875",
+      "selectionBackground": "#3d2b23",
+      "background": "#231f1d",
+      "foreground": "#e6d5c2",
+      "black": "#2d2725",
+      "red": "#d1766e",
+      "green": "#99af6b",
+      "yellow": "#fcba81",
+      "blue": "#58bdff",
+      "purple": "#9480ba",
+      "cyan": "#4e89a2",
+      "white": "#a09384",
+      "brightBlack": "#73665b",
+      "brightRed": "#d25780",
+      "brightGreen": "#43b16a",
+      "brightYellow": "#f4a21c",
+      "brightBlue": "#8bcfff",
+      "brightPurple": "#a692cd",
+      "brightCyan": "#20c9cb",
+      "brightWhite": "#e6d5c2"
+    }
+  ]
+}

--- a/extras/windows-terminal/cendre.json
+++ b/extras/windows-terminal/cendre.json
@@ -1,0 +1,27 @@
+{
+  "schemes": [
+    {
+      "name": "cendre",
+      "cursorColor": "#ea9875",
+      "selectionBackground": "#2f1e17",
+      "background": "#171311",
+      "foreground": "#e6d5c2",
+      "black": "#201b19",
+      "red": "#d1766e",
+      "green": "#99af6b",
+      "yellow": "#fcba81",
+      "blue": "#58bdff",
+      "purple": "#9480ba",
+      "cyan": "#4e89a2",
+      "white": "#a09384",
+      "brightBlack": "#73665b",
+      "brightRed": "#d25780",
+      "brightGreen": "#43b16a",
+      "brightYellow": "#f4a21c",
+      "brightBlue": "#8bcfff",
+      "brightPurple": "#a692cd",
+      "brightCyan": "#20c9cb",
+      "brightWhite": "#e6d5c2"
+    }
+  ]
+}

--- a/lua/cendre/extras/init.lua
+++ b/lua/cendre/extras/init.lua
@@ -33,6 +33,7 @@ local PER_DEPTH = {
   ["extras/konsole/cendre.colorscheme"] = terminals.konsole,
   ["extras/kde/cendre.colors"] = tools.kde,
   ["extras/macos-terminal/cendre.itermcolors"] = terminals.itermcolors,
+  ["extras/windows-terminal/cendre.json"] = terminals.windows_terminal,
   ["extras/macos-terminal/cendre.terminal"] = terminals.macos_terminal,
   ["extras/tmux/cendre.tmux.conf"] = terminals.tmux,
   ["extras/tmux/cendre.tokyo-night.sh"] = terminals.tokyo_night_tmux,

--- a/lua/cendre/extras/terminals.lua
+++ b/lua/cendre/extras/terminals.lua
@@ -349,6 +349,51 @@ function M.itermcolors(bg)
 ]]):format(table.concat(body, "\n"))
 end
 
+--- Windows Terminal, as a JSON fragment: the file drops into Fragments/ whole, or
+--- the object inside it goes in the `schemes` array of settings.json.
+--- @param bg string
+--- @return string
+function M.windows_terminal(bg)
+  local c = palette.get(bg)
+  local slots = ansi(c)
+
+  -- TableColorsMapping in ColorScheme.cpp, in the order ToJson writes back. Its
+  -- "magenta" and "brightMagenta" are second names for slots 5 and 13, and the
+  -- read loop counts keys rather than slots, so spelling one slot twice validates
+  -- a scheme with another slot left on Campbell.
+  local names = {
+    "black", "red", "green", "yellow", "blue", "purple", "cyan", "white",
+    "brightBlack", "brightRed", "brightGreen", "brightYellow",
+    "brightBlue", "brightPurple", "brightCyan", "brightWhite",
+  }
+
+  local entries = {
+    { "name", palette.name(bg) },
+    { "cursorColor", c.ember },
+    { "selectionBackground", c.vis },
+    { "background", c.bg0 },
+    { "foreground", c.fg },
+  }
+  for i, key in ipairs(names) do
+    table.insert(entries, { key, slots[i] })
+  end
+
+  local body = {}
+  for i, e in ipairs(entries) do
+    table.insert(body, ('      "%s": "%s"%s'):format(e[1], e[2], i < #entries and "," or ""))
+  end
+
+  return ([[
+{
+  "schemes": [
+    {
+%s
+    }
+  ]
+}
+]]):format(table.concat(body, "\n"))
+end
+
 --- @param bg string
 --- @return string
 --- A theme block for the tokyo-night-tmux plugin, which reads its colours from a

--- a/test/smoke.lua
+++ b/test/smoke.lua
@@ -616,6 +616,7 @@ check("no two depths of one surface share a theme name", function()
       "extras/obsidian/cendre%s/manifest.json",
       "extras/firefox/cendre%s/manifest.json",
       "extras/tmux/cendre%s.tokyo-night.sh",
+      "extras/windows-terminal/cendre%s.json",
     }) do
       local path = target:format(suffix)
       local body = files[path]
@@ -991,6 +992,60 @@ check("the konsole scheme carries the sections konsole ships", function()
       assert(body:find("Description=" .. name .. "\n", 1, true),
         path .. " does not name itself in [General]")
     end
+  end
+end)
+
+check("the windows terminal scheme carries the keys ColorScheme.cpp reads", function()
+  reload()
+  local palette = require("cendre.palette")
+  package.loaded["cendre.extras"] = nil
+  local files = require("cendre.extras").files()
+
+  -- ColorScheme::_layerJson reads five named keys, then walks TableColorsMapping.
+  -- A scheme short of one table colour is rejected whole rather than half applied,
+  -- which is the opposite of what yazi and hunk do.
+  local table_colours = {
+    "black", "red", "green", "yellow", "blue", "purple", "cyan", "white",
+    "brightBlack", "brightRed", "brightGreen", "brightYellow",
+    "brightBlue", "brightPurple", "brightCyan", "brightWhite",
+  }
+  local want = {
+    name = true, foreground = true, background = true,
+    selectionBackground = true, cursorColor = true,
+  }
+  for _, key in ipairs(table_colours) do
+    want[key] = true
+  end
+
+  for _, bg in ipairs(palette.backgrounds) do
+    local suffix = bg == palette.default and "" or ("-" .. bg)
+    local path = ("extras/windows-terminal/cendre%s.json"):format(suffix)
+    local body = files[path]
+    assert(body, "missing " .. path)
+
+    local seen = {}
+    for key in body:gmatch('"([%w]+)"%s*:%s*"') do
+      seen[key] = true
+    end
+    for key in pairs(want) do
+      assert(seen[key], path .. " has no " .. key)
+    end
+    for key in pairs(seen) do
+      assert(want[key], path .. " invents " .. key)
+    end
+
+    for _, alias in ipairs({ "magenta", "brightMagenta" }) do
+      assert(not seen[alias], path .. " writes " .. alias .. ", a second name for a slot it already fills")
+    end
+
+    for key, value in body:gmatch('"([%w]+)"%s*:%s*"([^"]+)"') do
+      if key ~= "name" then
+        assert(value:match("^#%x%x%x$") or value:match("^#%x%x%x%x%x%x$"),
+          path .. " gives " .. key .. " a value that is not a hex colour: " .. value)
+      end
+    end
+
+    assert(body:find('"schemes"', 1, true), path .. " is not a fragment: no schemes list")
   end
 end)
 


### PR DESCRIPTION
## What this changes

Windows Terminal, asked for in #76. Three files under `extras/windows-terminal/`, one per depth, plus the row on the site and the count that goes with it.

Each file is a JSON fragment, so it works both ways a reader might install it: dropped whole into `%LOCALAPPDATA%\Microsoft\Windows Terminal\Fragments\cendre\`, or with the object inside pasted into the `schemes` array of `settings.json`. Same object, same parser, either route.

```json
{
  "schemes": [
    {
      "name": "cendre",
      "cursorColor": "#ea9875",
      "selectionBackground": "#2f1e17",
      "background": "#171311",
      "foreground": "#e6d5c2",
      "black": "#201b19",
      ...
    }
  ]
}
```

## Where the key list comes from

`src/cascadia/TerminalSettingsModel/ColorScheme.cpp`, not the docs page. `_layerJson` reads five named keys and then walks `TableColorsMapping`, and that table has eighteen entries for sixteen slots: `magenta` and `brightMagenta` were added in GH#11456 as second names for slots 5 and 13.

The loop counts keys it found, not slots it filled, and breaks at sixteen:

```cpp
colorCount += JsonUtils::GetValueForKey(json, key, til::at(_table, index));
if (colorCount == ColorSchemeExpectedSize) { break; }
...
isValid &= (colorCount == 16);
```

So a scheme that writes both `purple` and `magenta` can reach sixteen with a slot never assigned, and that slot keeps the Campbell value the constructor copied in. It validates and it is wrong. Only the canonical sixteen are written, and the test fails on either alias.

One thing Windows Terminal does better than yazi and hunk: short of a table colour, `FromJson` returns `nullptr` and the whole scheme is rejected. No half-applied theme to debug.

`name` is required, and it is stored in the file rather than taken from the filename, so it carries the depth suffix through `palette.name(bg)`. Otherwise the three depths collide on one entry, the same way they would in Zed or bat. `cursorColor` and `selectionBackground` are the two optional keys, documented as such, and both are written: left out, the cursor stays Campbell white over this ground.

## Commit messages

- [x] Every commit follows `type(scope): subject`

`feat(extras)`, one commit. This one bumps the minor, so the open release PR recomputes from 1.16.1 to 1.17.0.

## If this touches colours

- [x] Nothing under `extras/`, `assets/` or `docs/` was edited by hand
- [x] Regenerated with the command in `CONTRIBUTING.md`, and the regenerated files are committed
- [x] Every colour comes from the palette. Nothing hardcoded, nothing blended

The sixteen ANSI slots come from the same `ansi(c)` helper every other terminal writer indexes, and `background`, `foreground`, `cursorColor`, `selectionBackground` map to `bg0`, `fg`, `ember`, `vis`, which is what the iTerm2 and macOS Terminal files already do.

`CONTRIBUTING.md` and the PR template said 87 generated files. It was 93 before this and is 96 after, so both are corrected here.

## Verified

- [x] `smoke (stable)` passes locally, 61 checks

New check, `the windows terminal scheme carries the keys ColorScheme.cpp reads`: the twenty keys are all present, nothing else is invented, neither alias appears, every value parses as `#rgb` or `#rrggbb`, and the `schemes` wrapper is there. The three depths are also added to the existing check that no two depths of one surface share a theme name.
